### PR TITLE
[ING-03] Lisa Redis single-flight lukk sünkroonimistöödele

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,10 @@ POSTGRES_PASSWORD=change-me-before-production
 POSTGRES_HOST=db
 POSTGRES_PORT=5432
 
+# Redis reservation TTL for tenant-scoped synchronization single-flight locks.
+# The default is 900 seconds; increase it only when a normal sync demonstrably needs longer.
+FORESTIQ_SINGLE_FLIGHT_LOCK_TTL_SECONDS=900
+
 # Used only by `python manage.py import_legacy_metsis --confirm`.
 # LEGACY_DATABASE_URL=postgresql://readonly_user:password@legacy-host:5432/metsis
 

--- a/django_backend/api/parity.py
+++ b/django_backend/api/parity.py
@@ -811,13 +811,24 @@ def integration_start(request, key: str):
         return _detail("Forestek is a one-time initial import. Run the controlled management command only before its first successful import.", status.HTTP_409_CONFLICT)
     cadastre_id = request.data.get("cadastreId") or request.data.get("parameters", {}).get("cadastreId")
     if cadastre_id:
-        run = enqueue_cadastre_sync(
+        dispatch = enqueue_cadastre_sync(
             str(cadastre_id),
             organization_id=str(request_organization_id(request)),
             requested_by_id=request.user.id,
             source=key.lower(),
         )
-        return Response({"key": key, "status": run.status, "runId": run.id, "taskId": run.task_id}, status=status.HTTP_202_ACCEPTED)
+        if dispatch.already_running:
+            return Response(
+                {
+                    "key": key,
+                    "status": "already_running",
+                    "code": "already_running",
+                    "runId": dispatch.run.id if dispatch.run else None,
+                    "taskId": dispatch.run.task_id if dispatch.run else "",
+                },
+                status=status.HTTP_409_CONFLICT,
+            )
+        return Response({"key": key, "status": dispatch.run.status, "runId": dispatch.run.id, "taskId": dispatch.run.task_id}, status=status.HTTP_202_ACCEPTED)
     if settings.FORESTIQ_TASKS_INLINE:
         result = enqueue_portfolio_sync(str(request_organization_id(request)))
         return Response({"key": key, "status": "SUCCEEDED", "result": result})
@@ -858,16 +869,19 @@ def registry_freshness(request):
 def registry_recover(request):
     batch_size = min(max(int(request.data.get("batchSize", 25)), 1), 200)
     queued = []
+    already_running = []
     for cadastre_id in _stale_cadastres().order_by("id").values_list("id", flat=True)[:batch_size]:
-        queued.append(
-            enqueue_cadastre_sync(
-                cadastre_id,
-                organization_id=str(request_organization_id(request)),
-                requested_by_id=request.user.id,
-                source="recovery",
-            ).id
+        dispatch = enqueue_cadastre_sync(
+            cadastre_id,
+            organization_id=str(request_organization_id(request)),
+            requested_by_id=request.user.id,
+            source="recovery",
         )
-    return Response({"queued": len(queued), "runIds": queued}, status=status.HTTP_202_ACCEPTED)
+        if dispatch.already_running:
+            already_running.append({"cadastreId": cadastre_id, "runId": dispatch.run.id if dispatch.run else None})
+        else:
+            queued.append(dispatch.run.id)
+    return Response({"queued": len(queued), "runIds": queued, "alreadyRunning": already_running}, status=status.HTTP_202_ACCEPTED)
 
 
 @api_view(["GET"])
@@ -879,13 +893,22 @@ def registry_health(request):
 
 def _registry_refresh(request, cadastre_id: str, source: str):
     get_object_or_404(Cadastre, id=cadastre_id)
-    run = enqueue_cadastre_sync(
+    dispatch = enqueue_cadastre_sync(
         cadastre_id,
         organization_id=str(request_organization_id(request)),
         requested_by_id=request.user.id,
         source=source,
     )
-    return Response({"id": run.id, "cadastreId": cadastre_id, "source": source, "status": run.status, "taskId": run.task_id}, status=status.HTTP_202_ACCEPTED)
+    if dispatch.already_running:
+        return Response(
+            {
+                "code": "already_running",
+                "detail": "A synchronization run is already active for this cadastre.",
+                "run": {"id": dispatch.run.id, "status": dispatch.run.status, "taskId": dispatch.run.task_id} if dispatch.run else None,
+            },
+            status=status.HTTP_409_CONFLICT,
+        )
+    return Response({"id": dispatch.run.id, "cadastreId": cadastre_id, "source": source, "status": dispatch.run.status, "taskId": dispatch.run.task_id}, status=status.HTTP_202_ACCEPTED)
 
 
 @api_view(["POST"])

--- a/django_backend/api/views.py
+++ b/django_backend/api/views.py
@@ -96,13 +96,22 @@ def sync_runs(request):
 def cadastre_sync(request, cadastre_id: str):
     """Queue one cadastral unit's source refresh through Celery."""
     cadastre = get_object_or_404(Cadastre, id=cadastre_id)
-    run = enqueue_cadastre_sync(
+    dispatch = enqueue_cadastre_sync(
         cadastre.id,
         organization_id=str(request_organization_id(request)),
         requested_by_id=request.user.id,
         source="api",
     )
-    return Response(_sync_run_data(run), status=status.HTTP_202_ACCEPTED)
+    if dispatch.already_running:
+        return Response(
+            {
+                "code": "already_running",
+                "detail": "A synchronization run is already active for this cadastre.",
+                "run": _sync_run_data(dispatch.run) if dispatch.run else None,
+            },
+            status=status.HTTP_409_CONFLICT,
+        )
+    return Response(_sync_run_data(dispatch.run), status=status.HTTP_202_ACCEPTED)
 
 
 @api_view(["GET"])

--- a/django_backend/config/settings.py
+++ b/django_backend/config/settings.py
@@ -170,6 +170,9 @@ CELERY_TASK_TIME_LIMIT = int(os.getenv("CELERY_TASK_TIME_LIMIT_SECONDS", "300"))
 CELERY_TASK_SOFT_TIME_LIMIT = int(os.getenv("CELERY_TASK_SOFT_TIME_LIMIT_SECONDS", "270"))
 CELERY_TASK_ACKS_LATE = True
 CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP = True
+# Redis võtme TTL väldib igavest lukku, kui worker või host katkeb keset sünkroonimist.
+# Vaikimisi 15 minutit katab Celery 5-minutilise tööläve koos retry-varuga.
+FORESTIQ_SINGLE_FLIGHT_LOCK_TTL_SECONDS = int(os.getenv("FORESTIQ_SINGLE_FLIGHT_LOCK_TTL_SECONDS", "900"))
 CELERY_BEAT_SCHEDULE = {
     "forestiq-daily-portfolio-sync": {
         "task": "forestry.tasks.enqueue_all_organizations_portfolio_sync",

--- a/django_backend/forestry/management/commands/sync_forestry_data.py
+++ b/django_backend/forestry/management/commands/sync_forestry_data.py
@@ -2,10 +2,10 @@
 
 from django.core.management.base import BaseCommand, CommandError
 
-from accounts.organization_selection import active_organization
 from accounts.organization_context import organization_scope
-from forestry.models import Cadastre, DataSyncRun
-from forestry.tasks import enqueue_cadastre_sync, run_cadastre_sync
+from accounts.organization_selection import active_organization
+from forestry.models import Cadastre
+from forestry.tasks import enqueue_cadastre_sync
 
 
 class Command(BaseCommand):
@@ -29,10 +29,14 @@ class Command(BaseCommand):
             for cadastre_id in ids:
                 if not Cadastre.objects.filter(id=cadastre_id).exists():
                     raise CommandError(f"Unknown cadastral unit: {cadastre_id}")
-                if options["inline"]:
-                    run = DataSyncRun.objects.create(cadastre_id=cadastre_id, source="manual-inline")
-                    run_cadastre_sync(run.id, str(organization.id))
-                    run.refresh_from_db()
+                dispatch = enqueue_cadastre_sync(
+                    cadastre_id,
+                    organization_id=str(organization.id),
+                    source="manual-inline" if options["inline"] else "manual",
+                    inline=options["inline"],
+                )
+                if dispatch.already_running:
+                    run_id = dispatch.run.id if dispatch.run else "unknown"
+                    self.stdout.write(self.style.WARNING(f"{cadastre_id}: already running (run {run_id})"))
                 else:
-                    run = enqueue_cadastre_sync(cadastre_id, organization_id=str(organization.id), source="manual")
-                self.stdout.write(f"{cadastre_id}: run {run.id} ({run.status})")
+                    self.stdout.write(f"{cadastre_id}: run {dispatch.run.id} ({dispatch.run.status})")

--- a/django_backend/forestry/services/single_flight.py
+++ b/django_backend/forestry/services/single_flight.py
@@ -1,0 +1,124 @@
+"""Redis-backed single-flight locks for externally sourced synchronization work."""
+
+from __future__ import annotations
+
+import logging
+import secrets
+from dataclasses import dataclass
+from typing import Final
+
+import redis
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+_RELEASE_IF_OWNED: Final = """
+if redis.call('get', KEYS[1]) == ARGV[1] then
+    return redis.call('del', KEYS[1])
+end
+return 0
+"""
+
+_CLAIM_QUEUED_OR_EXPIRED_LOCK: Final = """
+local current = redis.call('get', KEYS[1])
+if current == ARGV[1] then
+    redis.call('set', KEYS[1], ARGV[2], 'EX', ARGV[3])
+    return 1
+end
+if not current then
+    local acquired = redis.call('set', KEYS[1], ARGV[2], 'NX', 'EX', ARGV[3])
+    return acquired and 1 or 0
+end
+return 0
+"""
+
+
+class SingleFlightLockUnavailable(ConnectionError):
+    """Raised when Redis is unavailable and exclusivity therefore cannot be guaranteed."""
+
+
+@dataclass
+class SingleFlightLock:
+    """A token-owned Redis lock for one tenant-scoped synchronization activity.
+
+    A dispatcher first stores its random token as a queued reservation. The
+    worker atomically exchanges it for a running token, preventing duplicate
+    Celery deliveries from performing the same writes. The TTL recovers from a
+    stopped dispatcher or worker without ever deleting a newer worker's key.
+    """
+
+    key: str
+    ttl_seconds: int
+    token: str
+    owned_value: str = ""
+
+    @classmethod
+    def for_sync(cls, task_name: str, organization_id: str, scope: str = "") -> "SingleFlightLock":
+        parts = ["forestiq", "single-flight", "v1", task_name, str(organization_id)]
+        if scope:
+            parts.append(scope)
+        return cls(
+            key=":".join(parts),
+            ttl_seconds=settings.FORESTIQ_SINGLE_FLIGHT_LOCK_TTL_SECONDS,
+            token=secrets.token_urlsafe(24),
+        )
+
+    @property
+    def client(self):
+        return redis.from_url(settings.CELERY_BROKER_URL, decode_responses=True)
+
+    def acquire(self) -> bool:
+        """Acquire a lock immediately for work that begins in this process."""
+
+        try:
+            acquired = bool(self.client.set(self.key, self.token, nx=True, ex=self.ttl_seconds))
+        except redis.RedisError as exc:
+            raise SingleFlightLockUnavailable("Redis is unavailable; synchronization was not started.") from exc
+        if acquired:
+            self.owned_value = self.token
+        return acquired
+
+    def claim_queued_or_recover(self) -> bool:
+        """Claim this dispatcher's queued lock, or recover only after its TTL.
+
+        A successful claim changes the Redis value to a distinct running token.
+        Another delivery holding the old dispatch token therefore cannot enter
+        the critical section. If the queued reservation expired before a worker
+        began, this token may recover the key only when no newer owner exists.
+        """
+
+        running_value = f"running:{self.token}"
+        try:
+            claimed = bool(
+                self.client.eval(
+                    _CLAIM_QUEUED_OR_EXPIRED_LOCK,
+                    1,
+                    self.key,
+                    self.token,
+                    running_value,
+                    self.ttl_seconds,
+                )
+            )
+        except redis.RedisError as exc:
+            raise SingleFlightLockUnavailable("Redis is unavailable; synchronization ownership cannot be verified.") from exc
+        if claimed:
+            self.owned_value = running_value
+        return claimed
+
+    def release(self) -> None:
+        """Release the key only if this lock's token is still the stored owner."""
+
+        if not self.owned_value:
+            return
+        try:
+            self.client.eval(_RELEASE_IF_OWNED, 1, self.key, self.owned_value)
+        except redis.RedisError:
+            # A failed release cannot risk deleting a recovered worker's lock.
+            # The configured TTL remains the safe recovery mechanism.
+            logger.warning("Could not release single-flight lock %s; waiting for its TTL.", self.key, exc_info=True)
+
+
+def recover_or_acquire(lock: SingleFlightLock) -> bool:
+    """Acquire an immediate-execution lock, returning false when another run owns it."""
+
+    return lock.acquire()

--- a/django_backend/forestry/tasks.py
+++ b/django_backend/forestry/tasks.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import timedelta
 
 from celery import shared_task
@@ -18,6 +19,15 @@ from forestry.services.external_sync import (
     sync_parimus_inheritance,
 )
 from forestry.services.metsaregister_full_import import import_metsaregister_delta
+from forestry.services.single_flight import SingleFlightLock
+
+
+@dataclass(frozen=True)
+class CadastreSyncDispatch:
+    """Outcome of scheduling a tenant-scoped cadastre synchronization."""
+
+    run: DataSyncRun | None
+    already_running: bool = False
 
 
 def _start(run: DataSyncRun) -> None:
@@ -42,26 +52,54 @@ def _succeed(run: DataSyncRun, result: dict[str, object]) -> dict[str, object]:
     return result
 
 
+def _active_cadastre_run(cadastre_id: str) -> DataSyncRun | None:
+    """Find the audit row owned by a queued or executing cadastre refresh."""
+
+    return (
+        DataSyncRun.objects.filter(
+            cadastre_id=cadastre_id,
+            status__in=(DataSyncRun.Status.QUEUED, DataSyncRun.Status.RUNNING),
+        )
+        .order_by("-id")
+        .first()
+    )
+
+
 @shared_task(bind=True, autoretry_for=(ConnectionError,), retry_backoff=True, max_retries=3)
-def run_cadastre_sync(self, run_id: int, organization_id: str) -> dict[str, object]:
-    """Refresh recurring public registry data; Forestek is deliberately excluded."""
+def run_cadastre_sync(self, run_id: int, organization_id: str, lock_token: str = "") -> dict[str, object]:
+    """Refresh one cadastre while holding the dispatch-created single-flight lock."""
 
     with organization_scope(organization_id):
         run = DataSyncRun.objects.select_related("cadastre").get(id=run_id)
         if run.cadastre is None:
             raise ValueError("The requested cadastre no longer exists")
-        _start(run)
+        if run.status == DataSyncRun.Status.RUNNING:
+            return {"status": "already_running", "runId": run.id}
+        if run.status == DataSyncRun.Status.SUCCEEDED:
+            return {"status": "already_finished", "runId": run.id}
+        lock = SingleFlightLock.for_sync("cadastre-sync", organization_id, run.cadastre_id)
+        if lock_token:
+            lock.token = lock_token
+            acquired = lock.claim_queued_or_recover()
+        else:
+            acquired = lock.acquire()
+        if not acquired:
+            return {"status": "already_running", "runId": run.id}
         try:
-            result = {
-                "cadastre_wfs": sync_cadastre_wfs(run.cadastre_id, organization_id=organization_id),
-                "metsaregister_wfs": sync_metsaregister_wfs(run.cadastre_id, organization_id=organization_id),
-                "soos_wfs": sync_optional_soos_wfs(run.cadastre_id, organization_id=organization_id),
-                "parimus_inheritance": sync_parimus_inheritance(run.cadastre_id, organization_id=organization_id),
-            }
-        except Exception as exc:
-            _fail(run, exc)
-            raise
-        return _succeed(run, result)
+            _start(run)
+            try:
+                result = {
+                    "cadastre_wfs": sync_cadastre_wfs(run.cadastre_id, organization_id=organization_id),
+                    "metsaregister_wfs": sync_metsaregister_wfs(run.cadastre_id, organization_id=organization_id),
+                    "soos_wfs": sync_optional_soos_wfs(run.cadastre_id, organization_id=organization_id),
+                    "parimus_inheritance": sync_parimus_inheritance(run.cadastre_id, organization_id=organization_id),
+                }
+            except Exception as exc:
+                _fail(run, exc)
+                raise
+            return _succeed(run, result)
+        finally:
+            lock.release()
 
 
 def enqueue_cadastre_sync(
@@ -70,19 +108,33 @@ def enqueue_cadastre_sync(
     organization_id: str,
     requested_by_id: str | None = None,
     source: str = "all",
-) -> DataSyncRun:
-    """Create and dispatch one audit row under an explicit organization context."""
+    inline: bool | None = None,
+) -> CadastreSyncDispatch:
+    """Schedule a refresh once per tenant and cadastre, returning an existing run on conflict."""
 
     with organization_scope(organization_id):
         cadastre = Cadastre.objects.get(id=cadastre_id)
-        run = DataSyncRun.objects.create(cadastre=cadastre, requested_by_id=requested_by_id, source=source)
-        if settings.FORESTIQ_TASKS_INLINE:
-            run_cadastre_sync(run.id, str(organization_id))
-            return DataSyncRun.objects.get(id=run.id)
-        result = run_cadastre_sync.delay(run.id, str(organization_id))
-        run.task_id = result.id
-        run.save(update_fields=("task_id",))
-        return run
+        lock = SingleFlightLock.for_sync("cadastre-sync", organization_id, cadastre.id)
+        if not lock.acquire():
+            return CadastreSyncDispatch(run=_active_cadastre_run(cadastre.id), already_running=True)
+        try:
+            run = _active_cadastre_run(cadastre.id)
+            if run and run.status == DataSyncRun.Status.RUNNING:
+                lock.release()
+                return CadastreSyncDispatch(run=run, already_running=True)
+            if run is None:
+                run = DataSyncRun.objects.create(cadastre=cadastre, requested_by_id=requested_by_id, source=source)
+            run_inline = settings.FORESTIQ_TASKS_INLINE if inline is None else inline
+            if run_inline:
+                run_cadastre_sync(run.id, str(organization_id), lock.token)
+                return CadastreSyncDispatch(run=DataSyncRun.objects.get(id=run.id))
+            result = run_cadastre_sync.delay(run.id, str(organization_id), lock.token)
+            run.task_id = result.id
+            run.save(update_fields=("task_id",))
+            return CadastreSyncDispatch(run=run)
+        except Exception:
+            lock.release()
+            raise
 
 
 @shared_task
@@ -91,10 +143,14 @@ def enqueue_portfolio_sync(organization_id: str) -> dict[str, int]:
 
     with organization_scope(organization_id):
         queued = 0
+        already_running = 0
         for cadastre_id in Cadastre.objects.order_by("id").values_list("id", flat=True):
-            enqueue_cadastre_sync(cadastre_id, organization_id=organization_id, source="daily")
-            queued += 1
-        return {"queued": queued}
+            dispatch = enqueue_cadastre_sync(cadastre_id, organization_id=organization_id, source="daily")
+            if dispatch.already_running:
+                already_running += 1
+            else:
+                queued += 1
+        return {"queued": queued, "already_running": already_running}
 
 
 @shared_task
@@ -110,20 +166,26 @@ def enqueue_all_organizations_portfolio_sync() -> dict[str, int]:
 
 @shared_task(bind=True, autoretry_for=(ConnectionError,), retry_backoff=True, max_retries=3)
 def run_metsaregister_delta_check(self, organization_id: str) -> dict[str, object]:
-    """Periodically query the Metsaregister delta CQL filter and audit newly persisted allocations."""
+    """Run one tenant-scoped Metsaregister delta check, skipping a concurrent run."""
 
-    with organization_scope(organization_id):
-        now = timezone.now()
-        previous = DataSyncRun.objects.filter(source="celery:metsaregister-cql-delta", status=DataSyncRun.Status.SUCCEEDED, finished_at__isnull=False).order_by("-finished_at").first()
-        since = (previous.finished_at - timedelta(minutes=settings.FORESTIQ_METSAREGISTER_DELTA_OVERLAP_MINUTES)) if previous else now - timedelta(hours=settings.FORESTIQ_METSAREGISTER_DELTA_LOOKBACK_HOURS)
-        run = DataSyncRun.objects.create(source="celery:metsaregister-cql-delta", status=DataSyncRun.Status.RUNNING, started_at=now)
-        try:
-            report = import_metsaregister_delta(since=since, organization_id=organization_id)
-            result = {**report.data(), "since": since.isoformat()}
-        except Exception as exc:
-            _fail(run, exc)
-            raise
-        return _succeed(run, result)
+    lock = SingleFlightLock.for_sync("metsaregister-delta", organization_id)
+    if not lock.acquire():
+        return {"status": "already_running"}
+    try:
+        with organization_scope(organization_id):
+            now = timezone.now()
+            previous = DataSyncRun.objects.filter(source="celery:metsaregister-cql-delta", status=DataSyncRun.Status.SUCCEEDED, finished_at__isnull=False).order_by("-finished_at").first()
+            since = (previous.finished_at - timedelta(minutes=settings.FORESTIQ_METSAREGISTER_DELTA_OVERLAP_MINUTES)) if previous else now - timedelta(hours=settings.FORESTIQ_METSAREGISTER_DELTA_LOOKBACK_HOURS)
+            run = DataSyncRun.objects.create(source="celery:metsaregister-cql-delta", status=DataSyncRun.Status.RUNNING, started_at=now)
+            try:
+                report = import_metsaregister_delta(since=since, organization_id=organization_id)
+                result = {**report.data(), "since": since.isoformat()}
+            except Exception as exc:
+                _fail(run, exc)
+                raise
+            return _succeed(run, result)
+    finally:
+        lock.release()
 
 
 @shared_task

--- a/django_backend/forestry/tests.py
+++ b/django_backend/forestry/tests.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, Mock, patch
 
 from django.core.management import call_command
 from django.core.management.base import CommandError
-from django.test import TestCase, override_settings
+from django.test import SimpleTestCase, TestCase, override_settings
 from django.utils import timezone
 from django.contrib.gis.geos import MultiPolygon, Polygon
 from rest_framework.test import APIClient
@@ -18,7 +18,8 @@ from operations.models import Deal, DealStage
 from forestry.services import import_runner
 from forestry.services.external_sync import sync_cadastre_wfs, sync_parimus_inheritance
 from forestry.services.metsaregister_full_import import FullImportReport, import_metsaregister_delta
-from forestry.tasks import run_cadastre_sync, run_metsaregister_delta_check
+from forestry.tasks import enqueue_cadastre_sync, run_cadastre_sync, run_metsaregister_delta_check
+from forestry.services.single_flight import SingleFlightLock
 
 
 def authenticated_client(user: User) -> APIClient:
@@ -391,3 +392,132 @@ class MapFeatureTests(TestCase):
         self.assertTrue(active_response.data["features"])
         self.assertEqual(recent.status_code, 200, recent.data)
         self.assertIn(self.cadastre.id, [feature["properties"]["id"] for feature in recent.data["features"]])
+
+
+class FakeRedis:
+    """Minimal Redis replacement for deterministic single-flight lock tests."""
+
+    def __init__(self):
+        self.values = {}
+        self.ttls = {}
+
+    def set(self, key, value, nx=False, ex=None):
+        if nx and key in self.values:
+            return None
+        self.values[key] = value
+        self.ttls[key] = ex
+        return True
+
+    def get(self, key):
+        return self.values.get(key)
+
+    def eval(self, script, _number_of_keys, key, *args):
+        if len(args) == 1:
+            if self.values.get(key) == args[0]:
+                del self.values[key]
+                self.ttls.pop(key, None)
+                return 1
+            return 0
+        expected, replacement, ttl_seconds = args
+        current = self.values.get(key)
+        if current == expected or current is None:
+            self.values[key] = replacement
+            self.ttls[key] = int(ttl_seconds)
+            return 1
+        return 0
+
+    def expire(self, key):
+        self.values.pop(key, None)
+        self.ttls.pop(key, None)
+
+
+class SingleFlightLockTests(SimpleTestCase):
+    @patch("forestry.services.single_flight.redis.from_url")
+    def test_lock_has_ttl_releases_only_its_owner_and_recovers_after_expiry(self, redis_from_url):
+        redis_client = FakeRedis()
+        redis_from_url.return_value = redis_client
+        first = SingleFlightLock.for_sync("cadastre-sync", "org-1", "79501:001:0001")
+        second = SingleFlightLock.for_sync("cadastre-sync", "org-1", "79501:001:0001")
+
+        self.assertTrue(first.acquire())
+        self.assertEqual(redis_client.ttls[first.key], 900)
+        self.assertFalse(second.acquire())
+        second.release()
+        self.assertEqual(redis_client.get(first.key), first.token)
+
+        redis_client.expire(first.key)
+        self.assertTrue(second.acquire())
+        first.release()
+        self.assertEqual(redis_client.get(second.key), second.token)
+
+    @patch("forestry.services.single_flight.redis.from_url")
+    def test_queued_dispatch_token_can_be_claimed_by_only_one_worker(self, redis_from_url):
+        redis_client = FakeRedis()
+        redis_from_url.return_value = redis_client
+        dispatcher = SingleFlightLock.for_sync("cadastre-sync", "org-1", "79501:001:0001")
+        first_worker = SingleFlightLock.for_sync("cadastre-sync", "org-1", "79501:001:0001")
+        second_worker = SingleFlightLock.for_sync("cadastre-sync", "org-1", "79501:001:0001")
+
+        self.assertTrue(dispatcher.acquire())
+        first_worker.token = dispatcher.token
+        second_worker.token = dispatcher.token
+        self.assertTrue(first_worker.claim_queued_or_recover())
+        self.assertFalse(second_worker.claim_queued_or_recover())
+        self.assertTrue(redis_client.get(first_worker.key).startswith("running:"))
+
+    @patch("forestry.tasks.import_metsaregister_delta")
+    @patch("forestry.services.single_flight.redis.from_url")
+    def test_delta_task_returns_already_running_without_writes(self, redis_from_url, import_delta):
+        redis_client = FakeRedis()
+        redis_from_url.return_value = redis_client
+        existing = SingleFlightLock.for_sync("metsaregister-delta", "org-1")
+        self.assertTrue(existing.acquire())
+
+        result = run_metsaregister_delta_check.run("org-1")
+
+        self.assertEqual(result, {"status": "already_running"})
+        import_delta.assert_not_called()
+
+
+class SingleFlightDispatchTests(TestCase):
+    def setUp(self):
+        self.admin = User.objects.create_superuser("single-flight-admin", "Single flight administrator", "very-secure-admin-password")
+        self.cadastre = Cadastre.objects.create(id="79501:001:0007")
+        self.client = authenticated_client(self.admin)
+
+    @override_settings(FORESTIQ_TASKS_INLINE=False)
+    def test_competing_dispatch_returns_existing_run_and_ttl_allows_recovery(self):
+        redis_client = FakeRedis()
+        with patch("forestry.services.single_flight.redis.from_url", return_value=redis_client), patch("forestry.tasks.run_cadastre_sync.delay") as delay:
+            delay.return_value.id = "celery-single-flight-1"
+            first = enqueue_cadastre_sync(self.cadastre.id, organization_id=str(self.cadastre.organization_id), source="api")
+            second = enqueue_cadastre_sync(self.cadastre.id, organization_id=str(self.cadastre.organization_id), source="daily")
+
+            self.assertFalse(first.already_running)
+            self.assertTrue(second.already_running)
+            self.assertEqual(second.run.id, first.run.id)
+            self.assertEqual(DataSyncRun.objects.count(), 1)
+            delay.assert_called_once()
+
+            redis_client.expire(SingleFlightLock.for_sync("cadastre-sync", str(self.cadastre.organization_id), self.cadastre.id).key)
+            recovered = enqueue_cadastre_sync(self.cadastre.id, organization_id=str(self.cadastre.organization_id), source="recovery")
+
+        self.assertFalse(recovered.already_running)
+        self.assertEqual(recovered.run.id, first.run.id)
+        self.assertEqual(DataSyncRun.objects.count(), 1)
+        self.assertEqual(delay.call_count, 2)
+
+    @override_settings(FORESTIQ_TASKS_INLINE=False)
+    def test_api_returns_already_running_instead_of_creating_a_duplicate_run(self):
+        redis_client = FakeRedis()
+        url = f"/api/services/admin/cadastres/{self.cadastre.id}/sync"
+        with patch("forestry.services.single_flight.redis.from_url", return_value=redis_client), patch("forestry.tasks.run_cadastre_sync.delay") as delay:
+            delay.return_value.id = "celery-single-flight-2"
+            first = self.client.post(url)
+            second = self.client.post(url)
+
+        self.assertEqual(first.status_code, 202, first.data)
+        self.assertEqual(second.status_code, 409, second.data)
+        self.assertEqual(second.data["code"], "already_running")
+        self.assertEqual(second.data["run"]["id"], first.data["id"])
+        self.assertEqual(DataSyncRun.objects.count(), 1)


### PR DESCRIPTION
## Kokkuvõte

Rakendab issue #26: tenant-põhine Redis single-flight lukk sünkroonimistöödele.

## Muudatused

- Lisab tokenipõhise Redis-luku cadastre ja Metsaregistri delta sünkroonimistöödele.
- Lukk kasutab TTL-i ning tokeniga atomaarset release’i, seega katkestatud dispatch või worker taastub aegumise järel ilma uuema omaniku lukku kustutamata.
- Celery töö claim’ib queue-reservatsiooni eraldi running-tokeniks; duplikaatdeliver ei saa väliskirjutusi korrata.
- Konkurentne HTTP käivitus tagastab `409` koos koodiga `already_running` ja olemasoleva auditijooksu infoga.
- Käsurea `--inline` sünkroonimine kasutab sama dispatch-teed.
- Lisab luku omanduse, TTL-taastumise, duplikaatdeliveri, delta-töö ning API konkurentsivastuse testid.

## Kohalik kontroll

- `python manage.py test forestry.tests.SingleFlightLockTests --verbosity 2`
- `python manage.py makemigrations --check --dry-run`
- `python manage.py check`

Closes #26