### PR TITLE
[API-01] Lisa versioonitud API v1 ja OpenAPI contract-diff

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -78,6 +78,13 @@ jobs:
         working-directory: django_backend
         run: python manage.py check
 
+      - name: Generate and verify the versioned OpenAPI contract
+        working-directory: django_backend
+        run: |
+          python manage.py spectacular --file ../api_contracts/openapi-v1.generated.yaml --validate --urlconf config.api_v1_urls
+          diff --unified=3 ../api_contracts/openapi-v1.yaml ../api_contracts/openapi-v1.generated.yaml
+          rm ../api_contracts/openapi-v1.generated.yaml
+
       - name: Run Django test suite
         working-directory: django_backend
         run: python manage.py test --verbosity 2

--- a/api_contracts/openapi-v1.yaml
+++ b/api_contracts/openapi-v1.yaml
@@ -1,0 +1,1640 @@
+openapi: 3.0.3
+info:
+  title: ForestIQ-D API
+  version: 1.0.0
+  description: Versioned compatibility API for the ForestIQ Django rewrite.
+paths:
+  /api/v1/oidc/config:
+    get:
+      operationId: oidc_config_retrieve
+      description: Expose only browser-safe Keycloak Authorization Code + PKCE metadata.
+      tags:
+      - oidc
+      security:
+      - {}
+      responses:
+        '200':
+          description: No response body
+  /api/v1/oidc/exchange:
+    post:
+      operationId: oidc_exchange_create
+      description: Exchange a PKCE authorization code and create the internal tenant
+        JWT.
+      tags:
+      - oidc
+      security:
+      - {}
+      responses:
+        '200':
+          description: No response body
+  /api/v1/password-login:
+    post:
+      operationId: password_login_create
+      tags:
+      - password-login
+      security:
+      - {}
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/admin-workdesk/assign:
+    post:
+      operationId: services_admin_workdesk_assign_create
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/admin-workdesk/owners-search:
+    get:
+      operationId: services_admin_workdesk_owners_search_retrieve
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/admin-workdesk/prepare:
+    get:
+      operationId: services_admin_workdesk_prepare_retrieve
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/admin/cadastres/{cadastre_id}/sync:
+    post:
+      operationId: services_admin_cadastres_sync_create
+      description: Queue one cadastral unit's source refresh through Celery.
+      parameters:
+      - in: path
+        name: cadastre_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/admin/integrations:
+    get:
+      operationId: services_admin_integrations_retrieve
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/admin/integrations/{key}/runs:
+    get:
+      operationId: services_admin_integrations_runs_retrieve_2
+      parameters:
+      - in: path
+        name: key
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+    post:
+      operationId: services_admin_integrations_runs_create
+      parameters:
+      - in: path
+        name: key
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/admin/integrations/{key}/runs/recent:
+    get:
+      operationId: services_admin_integrations_runs_recent_retrieve
+      parameters:
+      - in: path
+        name: key
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/admin/integrations/runs/{run_id}:
+    get:
+      operationId: services_admin_integrations_runs_retrieve
+      parameters:
+      - in: path
+        name: run_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/admin/sync-runs:
+    get:
+      operationId: services_admin_sync_runs_retrieve
+      description: Return the recent audit trail for administrator-initiated source
+        refreshes.
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/admin/users:
+    get:
+      operationId: services_admin_users_retrieve
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+    post:
+      operationId: services_admin_users_create
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/admin/users/{user_id}:
+    post:
+      operationId: services_admin_users_create_2
+      parameters:
+      - in: path
+        name: user_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+    delete:
+      operationId: services_admin_users_destroy
+      parameters:
+      - in: path
+        name: user_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '204':
+          description: No response body
+  /api/v1/services/admin/userstatistics/owner-status-change:
+    get:
+      operationId: services_admin_userstatistics_owner_status_change_retrieve
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/admin/userstatistics/prep-data:
+    get:
+      operationId: services_admin_userstatistics_prep_data_retrieve
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/cadastres/{cadastre_id}:
+    get:
+      operationId: services_cadastres_retrieve
+      parameters:
+      - in: path
+        name: cadastre_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/cadastres/{cadastre_id}/areas:
+    get:
+      operationId: services_cadastres_areas_retrieve
+      parameters:
+      - in: path
+        name: cadastre_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/cadastres/{cadastre_id}/evaluation:
+    get:
+      operationId: services_cadastres_evaluation_retrieve
+      parameters:
+      - in: path
+        name: cadastre_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+    post:
+      operationId: services_cadastres_evaluation_create
+      parameters:
+      - in: path
+        name: cadastre_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/cadastres/{cadastre_id}/labels:
+    get:
+      operationId: services_cadastres_labels_retrieve
+      parameters:
+      - in: path
+        name: cadastre_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+    post:
+      operationId: services_cadastres_labels_create
+      parameters:
+      - in: path
+        name: cadastre_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+    delete:
+      operationId: services_cadastres_labels_destroy
+      parameters:
+      - in: path
+        name: cadastre_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '204':
+          description: No response body
+  /api/v1/services/cadastres/{cadastre_id}/labels/{label}:
+    get:
+      operationId: services_cadastres_labels_retrieve_2
+      parameters:
+      - in: path
+        name: cadastre_id
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: label
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+    post:
+      operationId: services_cadastres_labels_create_2
+      parameters:
+      - in: path
+        name: cadastre_id
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: label
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+    delete:
+      operationId: services_cadastres_labels_destroy_2
+      parameters:
+      - in: path
+        name: cadastre_id
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: label
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '204':
+          description: No response body
+  /api/v1/services/cadastres/{cadastre_id}/mkdata:
+    get:
+      operationId: services_cadastres_mkdata_retrieve
+      parameters:
+      - in: path
+        name: cadastre_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/cadastres/{cadastre_id}/notifications:
+    get:
+      operationId: services_cadastres_notifications_retrieve
+      parameters:
+      - in: path
+        name: cadastre_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/cadastres/{cadastre_id}/registry-features:
+    get:
+      operationId: services_cadastres_registry_features_retrieve
+      parameters:
+      - in: path
+        name: cadastre_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/cadastres/{cadastre_id}/workspace:
+    get:
+      operationId: services_cadastres_workspace_retrieve
+      description: Return an access-controlled, map-first workspace payload for one
+        cadastral unit.
+      parameters:
+      - in: path
+        name: cadastre_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/caller-workdesk-prep-data:
+    get:
+      operationId: services_caller_workdesk_prep_data_retrieve
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/change-my-password:
+    post:
+      operationId: services_change_my_password_create
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/contract-starter:
+    get:
+      operationId: services_contract_starter_retrieve
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/contracts:
+    get:
+      operationId: services_contracts_retrieve
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+    post:
+      operationId: services_contracts_create
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/contracts/{contract_id}:
+    get:
+      operationId: services_contracts_retrieve_2
+      parameters:
+      - in: path
+        name: contract_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+    delete:
+      operationId: services_contracts_destroy
+      parameters:
+      - in: path
+        name: contract_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '204':
+          description: No response body
+  /api/v1/services/contracts/{contract_id}/document:
+    post:
+      operationId: services_contracts_document_create
+      description: Store an uploaded contract under the configured local media directory.
+      parameters:
+      - in: path
+        name: contract_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/contracts/{contract_id}/pdf:
+    get:
+      operationId: services_contracts_pdf_retrieve
+      parameters:
+      - in: path
+        name: contract_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/contracts/cadastre-details/{cadastre_id}:
+    get:
+      operationId: services_contracts_cadastre_details_retrieve
+      parameters:
+      - in: path
+        name: cadastre_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/contracts/deals/{deal_id}/draft:
+    get:
+      operationId: services_contracts_deals_draft_retrieve
+      parameters:
+      - in: path
+        name: deal_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/contracts/generate-from-deal:
+    post:
+      operationId: services_contracts_generate_from_deal_create
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/contracts/owner-details/{owner_id}:
+    get:
+      operationId: services_contracts_owner_details_retrieve
+      parameters:
+      - in: path
+        name: owner_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+    post:
+      operationId: services_contracts_owner_details_create
+      parameters:
+      - in: path
+        name: owner_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/contracts/suggestors/cadastre/{cadastre_id}:
+    get:
+      operationId: services_contracts_suggestors_cadastre_retrieve
+      parameters:
+      - in: path
+        name: cadastre_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/contracts/suggestors/owner/{owner_id}:
+    get:
+      operationId: services_contracts_suggestors_owner_retrieve
+      parameters:
+      - in: path
+        name: owner_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/deals/{deal_id}/commercial:
+    get:
+      operationId: services_deals_commercial_retrieve
+      parameters:
+      - in: path
+        name: deal_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/deals/{deal_id}/commercial/cancelled:
+    post:
+      operationId: services_deals_commercial_cancelled_create
+      parameters:
+      - in: path
+        name: deal_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/deals/{deal_id}/commercial/counteroffers:
+    post:
+      operationId: services_deals_commercial_counteroffers_create
+      parameters:
+      - in: path
+        name: deal_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/deals/{deal_id}/commercial/lost:
+    post:
+      operationId: services_deals_commercial_lost_create
+      parameters:
+      - in: path
+        name: deal_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/deals/{deal_id}/commercial/offers:
+    post:
+      operationId: services_deals_commercial_offers_create
+      parameters:
+      - in: path
+        name: deal_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/deals/{deal_id}/commercial/offers/send:
+    post:
+      operationId: services_deals_commercial_offers_send_create
+      parameters:
+      - in: path
+        name: deal_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/deals/{deal_id}/commercial/won:
+    post:
+      operationId: services_deals_commercial_won_create
+      parameters:
+      - in: path
+        name: deal_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/deals/{deal_id}/evaluation-assignment:
+    put:
+      operationId: services_deals_evaluation_assignment_update
+      parameters:
+      - in: path
+        name: deal_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/deals/{deal_id}/evaluation-assignment/claim:
+    post:
+      operationId: services_deals_evaluation_assignment_claim_create
+      parameters:
+      - in: path
+        name: deal_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+    delete:
+      operationId: services_deals_evaluation_assignment_claim_destroy
+      parameters:
+      - in: path
+        name: deal_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '204':
+          description: No response body
+  /api/v1/services/deals/{deal_id}/evaluations:
+    post:
+      operationId: services_deals_evaluations_create
+      parameters:
+      - in: path
+        name: deal_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/deals/evaluation-queue:
+    get:
+      operationId: services_deals_evaluation_queue_retrieve
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/deals/owners/{owner_id}:
+    get:
+      operationId: services_deals_owners_retrieve
+      parameters:
+      - in: path
+        name: owner_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+    post:
+      operationId: services_deals_owners_create
+      parameters:
+      - in: path
+        name: owner_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/deals/owners/{owner_id}/brief:
+    get:
+      operationId: services_deals_owners_brief_retrieve
+      parameters:
+      - in: path
+        name: owner_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/inheritance/cases:
+    get:
+      operationId: services_inheritance_cases_retrieve
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/inheritance/cases/{case_id}:
+    get:
+      operationId: services_inheritance_cases_retrieve_2
+      parameters:
+      - in: path
+        name: case_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/inheritance/cases/{case_id}/assignment:
+    patch:
+      operationId: services_inheritance_cases_assignment_partial_update
+      parameters:
+      - in: path
+        name: case_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/inheritance/cases/{case_id}/events:
+    post:
+      operationId: services_inheritance_cases_events_create
+      parameters:
+      - in: path
+        name: case_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/inheritance/cases/{case_id}/heirs:
+    post:
+      operationId: services_inheritance_cases_heirs_create
+      parameters:
+      - in: path
+        name: case_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/inheritance/cases/{case_id}/heirs/{heir_id}:
+    put:
+      operationId: services_inheritance_cases_heirs_update
+      parameters:
+      - in: path
+        name: case_id
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: heir_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/inheritance/cases/{case_id}/status:
+    patch:
+      operationId: services_inheritance_cases_status_partial_update
+      parameters:
+      - in: path
+        name: case_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/inheritance/owners/{owner_id}:
+    get:
+      operationId: services_inheritance_owners_retrieve
+      parameters:
+      - in: path
+        name: owner_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+    post:
+      operationId: services_inheritance_owners_create
+      parameters:
+      - in: path
+        name: owner_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/inheritance/owners/{owner_id}/official-notices/{notice_number}/import:
+    post:
+      operationId: services_inheritance_owners_official_notices_import_create
+      parameters:
+      - in: path
+        name: notice_number
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: owner_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/inheritance/owners/{owner_id}/official-notices/check:
+    post:
+      operationId: services_inheritance_owners_official_notices_check_create
+      parameters:
+      - in: path
+        name: owner_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/map/cadastres:
+    get:
+      operationId: services_map_cadastres_retrieve
+      description: Return validated cadastral geometries as WGS84 GeoJSON for MapLibre.
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/map/layers/{layer}:
+    get:
+      operationId: services_map_layers_retrieve
+      description: Return validated GeoDjango layers as WGS84 GeoJSON for the MapLibre
+        client.
+      parameters:
+      - in: path
+        name: layer
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/map/tiles/{layer}/{z}/{x}/{y}.pbf:
+    get:
+      operationId: services_map_tiles_.pbf_retrieve
+      description: Return an organization-scoped Mapbox Vector Tile from PostGIS geometry.
+      parameters:
+      - in: path
+        name: layer
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: x
+        schema:
+          type: integer
+        required: true
+      - in: path
+        name: y
+        schema:
+          type: integer
+        required: true
+      - in: path
+        name: z
+        schema:
+          type: integer
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/messages/new-count:
+    get:
+      operationId: services_messages_new_count_retrieve
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/messages/new/count:
+    get:
+      operationId: services_messages_new_count_retrieve_2
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/messages/read:
+    post:
+      operationId: services_messages_read_create
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/messages/received:
+    get:
+      operationId: services_messages_received_retrieve
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/messages/received/mark-as-read:
+    post:
+      operationId: services_messages_received_mark_as_read_create
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/messages/send:
+    post:
+      operationId: services_messages_send_create
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/messages/sent:
+    get:
+      operationId: services_messages_sent_retrieve
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/messages/usernames:
+    get:
+      operationId: services_messages_usernames_retrieve
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/messages/users:
+    get:
+      operationId: services_messages_users_retrieve
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/metsis-portfolio/status:
+    get:
+      operationId: services_metsis_portfolio_status_retrieve
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/metsis-portfolio/sync:
+    post:
+      operationId: services_metsis_portfolio_sync_create
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/my-work:
+    get:
+      operationId: services_my_work_retrieve
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/my-work/next-owner:
+    get:
+      operationId: services_my_work_next_owner_retrieve
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/owner-statuses:
+    get:
+      operationId: services_owner_statuses_retrieve
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+    post:
+      operationId: services_owner_statuses_create
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/owner-statuses/{status_id}:
+    delete:
+      operationId: services_owner_statuses_destroy
+      parameters:
+      - in: path
+        name: status_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '204':
+          description: No response body
+  /api/v1/services/owner/{owner_id}/assignee:
+    post:
+      operationId: services_owner_assignee_create
+      parameters:
+      - in: path
+        name: owner_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/owner/{owner_id}/followings:
+    get:
+      operationId: services_owner_followings_retrieve
+      parameters:
+      - in: path
+        name: owner_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/owner/{owner_id}/followings/{user_id}:
+    post:
+      operationId: services_owner_followings_create
+      parameters:
+      - in: path
+        name: owner_id
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: user_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+    delete:
+      operationId: services_owner_followings_destroy
+      parameters:
+      - in: path
+        name: owner_id
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: user_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '204':
+          description: No response body
+  /api/v1/services/owner/{owner_id}/status:
+    get:
+      operationId: services_owner_status_retrieve
+      parameters:
+      - in: path
+        name: owner_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+    post:
+      operationId: services_owner_status_create
+      parameters:
+      - in: path
+        name: owner_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/owners:
+    get:
+      operationId: services_owners_retrieve
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/owners-in-need-of-evaluation:
+    get:
+      operationId: services_owners_in_need_of_evaluation_retrieve
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/owners/{owner_id}:
+    get:
+      operationId: services_owners_retrieve_2
+      parameters:
+      - in: path
+        name: owner_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+    post:
+      operationId: services_owners_create
+      parameters:
+      - in: path
+        name: owner_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/owners/{owner_id}/add:
+    post:
+      operationId: services_owners_add_create
+      parameters:
+      - in: path
+        name: owner_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/owners/{owner_id}/change-status:
+    get:
+      operationId: services_owners_change_status_retrieve
+      parameters:
+      - in: path
+        name: owner_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+    post:
+      operationId: services_owners_change_status_create
+      parameters:
+      - in: path
+        name: owner_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/owners/{owner_id}/log:
+    get:
+      operationId: services_owners_log_retrieve
+      parameters:
+      - in: path
+        name: owner_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+    post:
+      operationId: services_owners_log_create
+      parameters:
+      - in: path
+        name: owner_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/owners/{owner_id}/mark-cadastres:
+    post:
+      operationId: services_owners_mark_cadastres_create
+      parameters:
+      - in: path
+        name: owner_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/owners/imports/batches:
+    get:
+      operationId: services_owners_imports_batches_retrieve
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/owners/imports/batches/{batch_id}/errors.csv:
+    get:
+      operationId: services_owners_imports_batches_errors.csv_retrieve
+      parameters:
+      - in: path
+        name: batch_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/owners/imports/commit:
+    post:
+      operationId: services_owners_imports_commit_create
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/owners/imports/inspect:
+    post:
+      operationId: services_owners_imports_inspect_create
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/owners/imports/preview:
+    post:
+      operationId: services_owners_imports_preview_create
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/ownership-transitions/owners/{owner_id}:
+    get:
+      operationId: services_ownership_transitions_owners_retrieve
+      parameters:
+      - in: path
+        name: owner_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/ownership-transitions/sync:
+    post:
+      operationId: services_ownership_transitions_sync_create
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/persons-dump:
+    get:
+      operationId: services_persons_dump_retrieve
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+    post:
+      operationId: services_persons_dump_create
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/persons-dump/{person_id}:
+    delete:
+      operationId: services_persons_dump_destroy
+      parameters:
+      - in: path
+        name: person_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - services
+      responses:
+        '204':
+          description: No response body
+  /api/v1/services/registry/cadastres/{cadastre_id}/maaamet/refresh:
+    post:
+      operationId: services_registry_cadastres_maaamet_refresh_create
+      parameters:
+      - in: path
+        name: cadastre_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/registry/cadastres/{cadastre_id}/metsaregister/notifications/refresh:
+    post:
+      operationId: services_registry_cadastres_metsaregister_notifications_refresh_create
+      parameters:
+      - in: path
+        name: cadastre_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/registry/cadastres/{cadastre_id}/metsaregister/plan/refresh:
+    post:
+      operationId: services_registry_cadastres_metsaregister_plan_refresh_create
+      parameters:
+      - in: path
+        name: cadastre_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/registry/cadastres/{cadastre_id}/refresh-all:
+    post:
+      operationId: services_registry_cadastres_refresh_all_create
+      parameters:
+      - in: path
+        name: cadastre_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/registry/freshness:
+    get:
+      operationId: services_registry_freshness_retrieve
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/registry/freshness/recover:
+    post:
+      operationId: services_registry_freshness_recover_create
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/registry/health:
+    get:
+      operationId: services_registry_health_retrieve
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/registry/rik/cadastre-count:
+    post:
+      operationId: services_registry_rik_cadastre_count_create
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/reminders:
+    get:
+      operationId: services_reminders_retrieve
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+    post:
+      operationId: services_reminders_create
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/reminders-dashboard:
+    get:
+      operationId: services_reminders_dashboard_retrieve
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/reminders/{reminder_id}:
+    delete:
+      operationId: services_reminders_destroy
+      parameters:
+      - in: path
+        name: reminder_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - services
+      responses:
+        '204':
+          description: No response body
+  /api/v1/services/sales-workspace/owners/{owner_id}/outcome:
+    post:
+      operationId: services_sales_workspace_owners_outcome_create
+      parameters:
+      - in: path
+        name: owner_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/sales-workspace/queue:
+    get:
+      operationId: services_sales_workspace_queue_retrieve
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/status:
+    get:
+      operationId: services_status_retrieve
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/token-refresh:
+    post:
+      operationId: services_token_refresh_create
+      tags:
+      - services
+      security:
+      - {}
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/totp:
+    post:
+      operationId: services_totp_create
+      tags:
+      - services
+      security:
+      - {}
+      responses:
+        '200':
+          description: No response body
+components: {}

--- a/django_backend/api/tests_api_contract.py
+++ b/django_backend/api/tests_api_contract.py
@@ -1,0 +1,28 @@
+"""Regression tests for the versioned API compatibility surface."""
+
+from __future__ import annotations
+
+import yaml
+
+from django.test import SimpleTestCase
+from django.urls import resolve
+
+
+class ApiV1CompatibilityTests(SimpleTestCase):
+    def test_versioned_status_route_resolves_to_the_existing_public_view(self):
+        legacy = resolve("/api/services/status")
+        versioned = resolve("/api/v1/services/status")
+
+        self.assertIs(versioned.func, legacy.func)
+        legacy_response = self.client.get("/api/services/status")
+        versioned_response = self.client.get("/api/v1/services/status")
+        self.assertEqual(versioned_response.status_code, legacy_response.status_code)
+
+    def test_versioned_schema_is_public_and_contains_versioned_status_path(self):
+        response = self.client.get("/api/v1/schema/")
+
+        self.assertEqual(response.status_code, 200)
+        schema = yaml.safe_load(response.content)
+        self.assertEqual(schema["openapi"], "3.0.3")
+        self.assertEqual(schema["info"]["version"], "1.0.0")
+        self.assertIn("/api/v1/services/status", schema["paths"])

--- a/django_backend/config/api_v1_urls.py
+++ b/django_backend/config/api_v1_urls.py
@@ -1,0 +1,7 @@
+"""Versioned public API URL configuration used by the OpenAPI compatibility contract."""
+
+from django.urls import include, path
+
+urlpatterns = [
+    path("api/v1/", include("api.urls")),
+]

--- a/django_backend/config/settings.py
+++ b/django_backend/config/settings.py
@@ -27,6 +27,7 @@ INSTALLED_APPS = [
     "corsheaders",
     "rest_framework",
     "rest_framework_simplejwt.token_blacklist",
+    "drf_spectacular",
     "accounts",
     "forestry",
     "operations",
@@ -146,7 +147,18 @@ LOGGING = {
     },
 }
 
+SPECTACULAR_SETTINGS = {
+    "TITLE": "ForestIQ-D API",
+    "DESCRIPTION": "Versioned compatibility API for the ForestIQ Django rewrite.",
+    "VERSION": "1.0.0",
+    "SERVE_INCLUDE_SCHEMA": False,
+    "SCHEMA_PATH_PREFIX": r"/api/v1",
+    "SCHEMA_PATH_PREFIX_TRIM": False,
+    "SORT_OPERATIONS": True,
+}
+
 REST_FRAMEWORK = {
+    "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
     "DEFAULT_AUTHENTICATION_CLASSES": [
         "api.authentication.OrganizationJWTAuthentication",
     ],

--- a/django_backend/config/urls.py
+++ b/django_backend/config/urls.py
@@ -1,12 +1,19 @@
 """Root URL configuration for the ForestIQ Django service."""
 
-from django.contrib import admin
 from django.conf import settings
 from django.conf.urls.static import static
+from django.contrib import admin
 from django.urls import include, path
+from drf_spectacular.views import SpectacularAPIView
 
 urlpatterns = [
     path("django-admin/", admin.site.urls),
+    path(
+        "api/v1/schema/",
+        SpectacularAPIView.as_view(urlconf="config.api_v1_urls"),
+        name="openapi-v1-schema",
+    ),
+    path("api/v1/", include("api.urls")),
     path("api/", include("api.urls")),
 ]
 

--- a/docs/API_V1_COMPATIBILITY.md
+++ b/docs/API_V1_COMPATIBILITY.md
@@ -1,0 +1,72 @@
+# API v1 ühilduvusmaatriks
+
+## Eesmärk ja tõlgendus
+
+See dokument lukustab ForestIQ Java avalike HTTP- ja WebSocket-liideste pariteediseisu Django ümberkirjutuse versioonitud nimeruumis. Lähteinventar on [`endpoints.md`](../endpoints.md). Märgend **`equivalent`** tähendab, et avalik töövoog on saadaval sama sisulise käitumisega teel `/api/v1`; **`intentional difference`** tähendab teadlikku, dokumenteeritud erinevust; ja **`missing`** tähendab, et täpset avalikku vastet ei ole.
+
+Kõik tabelis olevad HTTP vasted eeldavad tavapärast API juurprefiksit `/api/v1`. Õiguste kontroll ja organisatsiooniisolatsioon jäävad Django API olemasoleva autentimiskihi ülesandeks.
+
+## Pariteediseis
+
+| Java avalik endpoint | Django v1 vaste või seis | Märgend | Selgitus |
+|---|---|---|---|
+| `POST /password-login` | `POST /password-login` | `equivalent` | Lokaalne kasutajanime/parooli sisselogimine. |
+| `POST /token-refresh` | `POST /services/token-refresh` | `equivalent` | JWT värskendus on säilitatud API teenuseruumis. |
+| `POST /totp` | `POST /services/totp` | `equivalent` | TOTP sisselogimine on säilitatud API teenuseruumis. |
+| `POST /change-my-password` | `POST /services/change-my-password` | `equivalent` | Kasutaja enda parooli muutmine. |
+| `GET /admin/users` | `GET /services/admin/users` | `equivalent` | Administraatori kasutajate loend. |
+| `POST /admin/users` | `POST /services/admin/users` | `equivalent` | Administraatori kasutaja loomine. |
+| `DELETE /admin/users/:user` | `DELETE /services/admin/users/{user_id}` | `equivalent` | Administraatori kasutaja eemaldamine. |
+| `POST /admin/users/:user` | `POST /services/admin/users/{user_id}` | `equivalent` | Administraatori kasutaja õiguste muutmine. |
+| `GET /admin/userstatistics/owner-status-change` | `GET /services/admin/userstatistics/owner-status-change` | `equivalent` | Omaniku staatuse muudatuste statistika. |
+| `GET /admin/userstatistics/prep-data` | `GET /services/admin/userstatistics/prep-data` | `equivalent` | Statistika tööruumi eeltäiteandmed. |
+| `GET /owner-statuses` | `GET /services/owner-statuses` | `equivalent` | Omaniku staatuste loend. |
+| `DELETE /owner-statuses/:id` | `DELETE /services/owner-statuses/{status_id}` | `equivalent` | Omaniku staatuse eemaldamine. |
+| `POST /owner-statuses` | `POST /services/owner-statuses` | `equivalent` | Omaniku staatuse loomine või muutmine. |
+| `POST /admin-workdesk/assign` | `POST /services/admin-workdesk/assign` | `equivalent` | Omanike massmääramine. |
+| `GET /admin-workdesk/owners-search` | `GET /services/admin-workdesk/owners-search` | `equivalent` | Töölauda toetav omanike otsing. |
+| `GET /admin-workdesk/prepare` | `GET /services/admin-workdesk/prepare` | `equivalent` | Töölauda toetavad eeltäiteandmed. |
+| `GET /contract-starter` | `GET /services/contract-starter` | `equivalent` | Lepingu algatamise andmed. |
+| `GET /contracts` | `GET /services/contracts` | `equivalent` | Lepingute loend. |
+| `POST /contracts` | `POST /services/contracts` | `equivalent` | Lepingu salvestamine. |
+| `GET /contracts/:id` | `GET /services/contracts/{contract_id}` | `equivalent` | Lepingu detail. |
+| `DELETE /contracts/:id` | `DELETE /services/contracts/{contract_id}` | `equivalent` | Lepingu eemaldamine. |
+| `GET /contracts/:id/pdf` | `GET /services/contracts/{contract_id}/pdf` | `equivalent` | Lepingu PDF-i allalaadimine. |
+| `GET /contracts/suggestors/cadastre/:id` | `GET /services/contracts/suggestors/cadastre/{cadastre_id}` | `equivalent` | Katastriüksuse soovitused. |
+| `GET /contracts/cadastre-details/:id` | `GET /services/contracts/cadastre-details/{cadastre_id}` | `equivalent` | Katastriüksuse lepinguandmed. |
+| `GET /contracts/suggestors/owner/:id` | `GET /services/contracts/suggestors/owner/{owner_id}` | `equivalent` | Omaniku soovitused. |
+| `GET /contracts/owner-details/:id` | `GET /services/contracts/owner-details/{owner_id}` | `equivalent` | Omaniku lepinguandmed. |
+| `GET /owners-in-need-of-evaluation` | `GET /services/owners-in-need-of-evaluation` | `equivalent` | Hindamist vajavate omanike järjekord. |
+| `DELETE /application-messages/:id` | Puudub | `missing` | Täpset vana rakendussõnumi REST-ressurssi ei ole üle toodud. |
+| `WS /application-messages` | Puudub | `missing` | Django ümberkirjutus pakub REST-sõnumeid, mitte samaväärset WebSocketi kanalit. |
+| `POST /cadastres/:id/labels/:label` | `POST /services/cadastres/{cadastre_id}/labels/{label}` | `equivalent` | Katastriüksuse märgendi lisamine. |
+| `GET /cadastres/:id/labels` | `GET /services/cadastres/{cadastre_id}/labels` | `equivalent` | Katastriüksuse märgendite loend. |
+| `DELETE /cadastres/:id/labels/:label` | `DELETE /services/cadastres/{cadastre_id}/labels/{label}` | `equivalent` | Katastriüksuse märgendi eemaldamine. |
+| `GET /cadastres/:id/notifications` | `GET /services/cadastres/{cadastre_id}/notifications` | `equivalent` | Metsateatiste loend. |
+| `GET /cadastres/:id/mkdata` | `GET /services/cadastres/{cadastre_id}/mkdata` | `equivalent` | Metsaregistri andmed. |
+| `GET /cadastres/:id/areas` | `GET /services/cadastres/{cadastre_id}/areas` | `equivalent` | Pindalade andmed. |
+| `GET /owners` | `GET /services/owners` | `equivalent` | Omanike otsing ja loend. |
+| `GET /owners/:id` | `GET /services/owners/{owner_id}` | `equivalent` | Omaniku detail. |
+| `POST /owners/:id` | `POST /services/owners/{owner_id}` | `equivalent` | Omaniku andmete muutmine. |
+| `GET /owner/:id/status` | `GET /services/owner/{owner_id}/status` | `equivalent` | Omaniku praegune staatus. |
+| `POST /owners/:id/change-status` | `POST /services/owners/{owner_id}/change-status` | `equivalent` | Omaniku staatuse muutmine. |
+| `POST /owners/:id/mark-cadastres` | `POST /services/owners/{owner_id}/mark-cadastres` | `equivalent` | Omaniku huvipakkuvate katastriüksuste märkimine. |
+| `POST /owners/:id/refresh-cadastres` | `POST /services/registry/cadastres/{cadastre_id}/maaamet/refresh` | `intentional difference` | Vana omanikupõhine välisvärskendus on asendatud auditeeritava administraatori katastriüksusepõhise registrivärskendusega. |
+| `POST /owners/:id/add` | `POST /services/owners/{owner_id}/add` | `equivalent` | Omaniku lisamine. |
+| `POST /owners/:id/log` | `POST /services/owners/{owner_id}/log` | `equivalent` | Omaniku tööajaloo sissekande loomine. |
+| `GET /owners/:id/log` | `GET /services/owners/{owner_id}/log` | `equivalent` | Omaniku tööajaloo loend. |
+| `POST /owner/:id/assignee` | `POST /services/owner/{owner_id}/assignee` | `equivalent` | Omaniku määramine kasutajale. |
+| `GET /my-work/next-owner` | `GET /services/my-work/next-owner` | `equivalent` | Järgmine määratud omanik. |
+| `GET /my-work` | `GET /services/my-work` | `equivalent` | Määratud omanike tööloend. |
+| `GET /caller-workdesk-prep-data` | `GET /services/caller-workdesk-prep-data` | `equivalent` | Helistaja töölauda toetavad eeltäiteandmed. |
+| `POST /reminders` | `POST /services/reminders` | `equivalent` | Meeldetuletuse loomine. |
+| `DELETE /reminders/:id` | `DELETE /services/reminders/{reminder_id}` | `equivalent` | Meeldetuletuse eemaldamine. |
+| `GET /reminders` | `GET /services/reminders` | `equivalent` | Kasutaja meeldetuletuste loend. |
+| `GET /persons-dump` | `GET /services/persons-dump` | `equivalent` | Õigusega piiratud kontaktide loend. |
+| `GET /status` | `GET /services/status` | `equivalent` | Teenuse seisundi kontroll. |
+
+## Lepingu kasutus
+
+`/api/v1/schema/` väljastab sama nimeruumi OpenAPI 3 skeemi. CI genereerib skeemi sellest URL-conf’ist ning võrdleb tulemust versioonihalduses oleva snapshot’iga [`api_contracts/openapi-v1.yaml`](../api_contracts/openapi-v1.yaml). Seetõttu ei saa lepingut muuta märkamatult: iga marsruudi, meetodi või genereeritud OpenAPI sisu muutus katkestab kvaliteedivärava, kuni snapshot muudetakse teadlikult samas pull request’is.
+
+> Maatriks on teadlikult eraldi OpenAPI skeemist. Skeem on täidetav, masinloetav leping; maatriks jäädvustab ka WebSocketi ning teadlikult erineva või puuduva Java liidese seisundi.

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ celery[redis]>=5.4,<5.5
 redis>=5.0,<6.0
 openpyxl>=3.1,<3.2
 requests>=2.32,<3.0
+drf-spectacular==0.28.0


### PR DESCRIPTION
## Kokkuvõte

Rakendab issue #16: versioonitud `/api/v1` ühilduvuskiht, Java avalike endpointide pariteedimaatriks ning CI-põhine OpenAPI contract-diff.

## Muudatused

- Lisab olemasoleva API muutmata semantikaga `/api/v1/` nimeruumi ja avaliku `/api/v1/schema/` OpenAPI skeemi.
- Lisab `drf-spectacular` generaatori ning stabiilse OpenAPI 3.0.3 seadistuse.
- Lisab 115 versioonitud marsruudiga `api_contracts/openapi-v1.yaml` snapshot’i.
- Lisab kvaliteediväravasse schema genereerimise, valideerimise ning snapshot-diff’i: muudatus katkestab kontrolli, kuni lepingufail on teadlikult uuendatud.
- Lisab 54 Java avaliku endpointi pariteedimaatriksi: 51 `equivalent`, 1 `intentional difference`, 2 `missing`.
- Lisab API v1 marsruudi ja skeemi regressioonitestid.

## Kohalik kontroll

- `python manage.py spectacular --file ../api_contracts/openapi-v1.generated.yaml --validate --urlconf config.api_v1_urls`
- `diff --unified=3 ../api_contracts/openapi-v1.yaml ../api_contracts/openapi-v1.generated.yaml`
- `python manage.py test api.tests_api_contract --verbosity 1`
- `python manage.py makemigrations --check --dry-run`
- `python manage.py check`

Closes #16