### PR TITLE
[ING-05] Ajasta Pärimus ametlike teadete import

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,3 +41,5 @@ FORESTIQ_WFS_MIN_REQUEST_INTERVAL_SECONDS=0.25
 # FORESTEK_API_TOKEN=
 # PARIMUS_API_URL=https://parimus.example
 # PARIMUS_API_TOKEN=
+# Pärimus ametlike teadete perioodilise impordi intervall sekundites (vaikimisi 6 h).
+FORESTIQ_PARIMUS_NOTICE_INTERVAL_SECONDS=21600

--- a/django_backend/api/tests.py
+++ b/django_backend/api/tests.py
@@ -199,6 +199,14 @@ class MainParityWorkflowTests(TestCase):
         self.assertEqual(len(response.data), 1)
         self.assertEqual(response.data[0]["source"], "cadastre")
 
+    def test_scheduled_parimus_notice_run_is_visible_in_integrations_audit(self):
+        DataSyncRun.objects.create(source="celery:parimus-official-notices", status=DataSyncRun.Status.SUCCEEDED, result={"cadastres": 1, "notices": 2})
+        response = self.client.get("/api/services/admin/integrations/PARIMUS/runs")
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["source"], "celery:parimus-official-notices")
+        self.assertEqual(response.data[0]["result"], {"cadastres": 1, "notices": 2})
+
 
 class MembershipRoleAuthorizationTests(TestCase):
     """AUTH-03: roles must apply within the active membership, not globally."""

--- a/django_backend/config/settings.py
+++ b/django_backend/config/settings.py
@@ -225,6 +225,10 @@ CELERY_BEAT_SCHEDULE = {
         "task": "forestry.tasks.enqueue_all_organizations_metsaregister_delta_check",
         "schedule": float(os.getenv("FORESTIQ_METSAREGISTER_DELTA_INTERVAL_SECONDS", "3600")),
     },
+    "forestiq-parimus-official-notices": {
+        "task": "forestry.tasks.enqueue_all_organizations_parimus_official_notice_import",
+        "schedule": float(os.getenv("FORESTIQ_PARIMUS_NOTICE_INTERVAL_SECONDS", "21600")),
+    },
 }
 FORESTIQ_TASKS_INLINE = env_bool("FORESTIQ_TASKS_INLINE", False)
 FORESTIQ_SYNC_HTTP_TIMEOUT_SECONDS = int(os.getenv("FORESTIQ_SYNC_HTTP_TIMEOUT_SECONDS", "30"))

--- a/django_backend/forestry/management/commands/configure_forestry_sync_schedule.py
+++ b/django_backend/forestry/management/commands/configure_forestry_sync_schedule.py
@@ -10,5 +10,5 @@ class Command(BaseCommand):
         parser.add_argument("--check", action="store_true", help="Exit successfully after printing the configured scheduler.")
 
     def handle(self, *args, **options):
-        self.stdout.write(self.style.SUCCESS("Celery Beat schedules ForestIQ portfolio and Forestek refreshes from CELERY_BEAT_SCHEDULE."))
+        self.stdout.write(self.style.SUCCESS("Celery Beat schedules ForestIQ portfolio, Metsaregister delta and Pärimus official-notice refreshes from CELERY_BEAT_SCHEDULE."))
         self.stdout.write("Start the scheduler with: celery -A config beat --loglevel=INFO")

--- a/django_backend/forestry/tasks.py
+++ b/django_backend/forestry/tasks.py
@@ -209,3 +209,51 @@ def enqueue_all_organizations_metsaregister_delta_check() -> dict[str, int]:
         result = run_metsaregister_delta_check.delay(str(organization_id))
         queued += 1 if result else 0
     return {"organizations": queued}
+
+
+@shared_task(bind=True, autoretry_for=(ConnectionError,), retry_backoff=True, max_retries=3)
+def run_parimus_official_notice_import(self, organization_id: str) -> dict[str, object]:
+    """Refresh Pärimus notices for one organization, even without a cadastre delta.
+
+    `InheritanceSignal` uses the provider's notice number together with the
+    organization and cadastre as its source key, so repeated polls update the
+    same projection instead of creating duplicate notices.
+    """
+
+    lock = SingleFlightLock.for_sync("parimus-official-notices", organization_id)
+    if not lock.acquire():
+        return {"status": "already_running"}
+    try:
+        with organization_scope(organization_id):
+            now = timezone.now()
+            run = DataSyncRun.objects.create(
+                source="celery:parimus-official-notices",
+                status=DataSyncRun.Status.RUNNING,
+                started_at=now,
+                task_id=self.request.id or "",
+                correlation_id=current_correlation_id(),
+            )
+            try:
+                cadastres = Cadastre.objects.order_by("id")
+                notices = sum(
+                    sync_parimus_inheritance(cadastre.id, organization_id=organization_id)
+                    for cadastre in cadastres.iterator()
+                )
+                result = {"cadastres": cadastres.count(), "notices": notices}
+            except Exception as exc:
+                _fail(run, exc)
+                raise
+            return _succeed(run, result)
+    finally:
+        lock.release()
+
+
+@shared_task
+def enqueue_all_organizations_parimus_official_notice_import() -> dict[str, int]:
+    """Beat entry point for auditable Pärimus official-notice refreshes."""
+
+    queued = 0
+    for organization_id in Organization.objects.filter(is_active=True).values_list("id", flat=True):
+        result = run_parimus_official_notice_import.delay(str(organization_id))
+        queued += 1 if result else 0
+    return {"organizations": queued}

--- a/django_backend/forestry/tests.py
+++ b/django_backend/forestry/tests.py
@@ -21,7 +21,12 @@ from operations.models import Deal, DealStage
 from forestry.services import import_runner
 from forestry.services.external_sync import sync_cadastre_wfs, sync_parimus_inheritance, wfs_features
 from forestry.services.metsaregister_full_import import FullImportReport, import_metsaregister_delta
-from forestry.tasks import enqueue_cadastre_sync, run_cadastre_sync, run_metsaregister_delta_check
+from forestry.tasks import (
+    enqueue_cadastre_sync,
+    run_cadastre_sync,
+    run_metsaregister_delta_check,
+    run_parimus_official_notice_import,
+)
 from forestry.services.single_flight import SingleFlightLock
 from forestry.services.wfs_client import WfsClient, WfsClientError, WfsClientPolicy
 
@@ -106,6 +111,28 @@ class InheritanceApiTests(TestCase):
         self.assertEqual(signal.cadastre_id, self.cadastre.id)
         self.assertEqual(signal.source_notice_number, "123456")
         self.assertEqual(get.call_args.kwargs["params"], {"personal_code": self.owner.id})
+
+    @override_settings(PARIMUS_API_URL="https://parimus.example.test", PARIMUS_API_TOKEN="unit-test-token")
+    @patch("forestry.services.external_sync.requests.get")
+    def test_parimus_source_notice_key_updates_instead_of_creating_duplicates(self, get):
+        get.return_value.json.return_value = {
+            "results": [
+                {
+                    "notice_number": "deduplicated-123",
+                    "announcement_date": "2026-08-20",
+                    "certification_deadline": "2026-10-20",
+                    "deceased_name": "Pärandaja",
+                    "source_url": "https://example.test/notice/deduplicated-123",
+                }
+            ]
+        }
+
+        with organization_scope(self.cadastre.organization_id):
+            sync_parimus_inheritance(self.cadastre.id, organization_id=str(self.cadastre.organization_id))
+            sync_parimus_inheritance(self.cadastre.id, organization_id=str(self.cadastre.organization_id))
+
+        self.assertEqual(self.owner.inheritance_signals.filter(source_notice_number="deduplicated-123").count(), 1)
+        self.assertEqual(get.call_count, 2)
 
 
 class SyncEndpointTests(TestCase):
@@ -642,3 +669,42 @@ class WfsClientTests(SimpleTestCase):
         with self.assertRaisesRegex(WfsClientError, "without retry"):
             bad_request.feature_page(base_url="https://wfs.example.test", layer="registry:layer", page_size=1)
         bad_request_get.assert_called_once()
+
+
+class ScheduledParimusNoticeImportTests(TestCase):
+    def setUp(self):
+        self.cadastre = Cadastre.objects.create(id="79501:001:0028")
+        self.organization = self.cadastre.organization
+
+    @override_settings(PARIMUS_API_URL="https://parimus.example.test", PARIMUS_API_TOKEN="unit-test-token")
+    def test_periodic_notice_import_creates_an_audited_organization_run(self):
+        redis_client = FakeRedis()
+        with (
+            patch("forestry.services.single_flight.redis.from_url", return_value=redis_client),
+            patch("forestry.tasks.sync_parimus_inheritance", return_value=2) as sync,
+        ):
+            result = run_parimus_official_notice_import.run(str(self.organization.id))
+
+        self.assertEqual(result, {"cadastres": 1, "notices": 2})
+        sync.assert_called_once_with(self.cadastre.id, organization_id=str(self.organization.id))
+        run = DataSyncRun.objects.get(source="celery:parimus-official-notices")
+        self.assertEqual(run.status, DataSyncRun.Status.SUCCEEDED)
+        self.assertEqual(run.result, result)
+        self.assertIsNone(run.cadastre)
+
+    def test_concurrent_periodic_notice_import_is_skipped_by_single_flight_lock(self):
+        redis_client = FakeRedis()
+        with patch("forestry.services.single_flight.redis.from_url", return_value=redis_client):
+            existing = SingleFlightLock.for_sync("parimus-official-notices", str(self.organization.id))
+            self.assertTrue(existing.acquire())
+            result = run_parimus_official_notice_import.run(str(self.organization.id))
+
+        self.assertEqual(result, {"status": "already_running"})
+        self.assertFalse(DataSyncRun.objects.filter(source="celery:parimus-official-notices").exists())
+
+    def test_beat_schedule_registers_the_periodic_notice_import(self):
+        from django.conf import settings
+
+        schedule = settings.CELERY_BEAT_SCHEDULE["forestiq-parimus-official-notices"]
+        self.assertEqual(schedule["task"], "forestry.tasks.enqueue_all_organizations_parimus_official_notice_import")
+        self.assertGreater(schedule["schedule"], 0)


### PR DESCRIPTION
## Kokkuvõte

Rakendab issue #28: eraldab Pärimus ametlike teadete perioodilise impordi iseseisvaks Celery tööks.

## Muudatused

- Lisab tenantipõhise `run_parimus_official_notice_import` Celery töö ja kõikide aktiivsete organisatsioonide Beat’i käivitaja.
- Lisab kuue tunni vaikimisi intervalliga `FORESTIQ_PARIMUS_NOTICE_INTERVAL_SECONDS` konfiguratsiooni ja näidiskeskkonna juhise.
- Töö loob nähtava `celery:parimus-official-notices` `DataSyncRun` auditikirje koos katastriüksuste ning töödeldud teadete koondiga.
- Töö kasutab Redis single-flight lukku, mistõttu paralleelne Beat’i või käsitsi käivitus tagastab `already_running` ega loo uut auditijooksu.
- Olemasolev Pärimus adapter kasutab allikavõtit `(organization, source_notice_number, cadastre)`, mille `update_or_create` käitumine hoiab korduspollid duplikaadivabad.
- Lisab testid perioodilisele auditijooksule, luku konkurentsile, Beat’i ajastusele, allikavõtme deduplikatsioonile ja integratsioonide auditivaatele.

## Kohalik kontroll

- `python -m compileall -q forestry/tasks.py forestry/tests.py api/tests.py config/settings.py`
- `python manage.py makemigrations --check --dry-run`
- `python manage.py check`
- `python manage.py configure_forestry_sync_schedule --check`

Täis Django/PostGIS-i testsuit käivitub kvaliteediväravas.

Closes #28