### PR TITLE
[OPS-01] Ekspordi Prometheus-mõõdikud API, Celery ja integratsioonide kohta

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,8 @@ POSTGRES_PORT=5432
 FORESTIQ_SINGLE_FLIGHT_LOCK_TTL_SECONDS=900
 # Maksimaalne administraatori poolt uuesti järjekorda pandavate sünkroonimisjooksude arv.
 FORESTIQ_SYNC_RUN_MAX_RETRIES=3
+# Valikuline Prometheuse scrape-token. Tootmises kasuta tugevat eraldi väärtust.
+FORESTIQ_METRICS_BEARER_TOKEN=
 
 # Bounded public WFS import policy: payload safety, retry/backoff and provider pacing.
 FORESTIQ_WFS_MAX_FEATURES=10000

--- a/README.md
+++ b/README.md
@@ -218,6 +218,12 @@ Server rakendab muudatuse ühe tingimusliku andmebaasivärskendusena: muudatus �
 | `Contract` | Olemasoleva lepingu andmed, fail ja kustutamine | Laadi lepingu detail uuesti; failimuudatust ei rakendata vanale versioonile. |
 | `InheritanceCase` | Staatus, määramine, pärijad ja märkmed | Värskenda juhtum koos sündmuste ja pärijate viimase seisuga. |
 
+### Prometheuse mõõdikud (OPS-01)
+
+Django protsess ekspordib Prometheuse vormingus mõõdikud aadressil `GET /metrics`. Mõõdikud hõlmavad API päringute kestust, staatuseklasside vealoendureid, Celery tööde kestust ja tulemust ning `DataSyncRun` auditi põhjal viimase edukuse aega, tõrkeseeriat, backlog’i ja cursor lag’i. HTTP marsruudi, töö ja integratsiooniallika sildid on tahtlikult piiratud väikese nimekirjaga; need ei sisalda katastri-, kasutaja-, taski- ega correlation ID-sid.
+
+Tootmises määra `FORESTIQ_METRICS_BEARER_TOKEN` tugevale eraldi saladusele ja anna Prometheusele scrape’iks päis `Authorization: Bearer <token>`. Tühja väärtuse korral jääb endpoint arendus- ja sisemise võrgu kasutuseks avatuks.
+
 ## Turve
 
 Django API kasutab organisatsiooniga seotud sisemist Bearer JWT-d. Reacti töölaud kasutab tootmises Keycloak’i Authorization Code + PKCE voogu; kohalik parooli/TOTP voog on ainult arenduseks. Õigused `ADMIN`, `OWNER_PROFILE`, `ASSIGNED_OWNERS`, `PHONES` ja `EVALUATION` tulenevad aktiivse organisatsiooniliikmesuse rollidest ning pärandõigused sünkroniseeritakse endiselt vastavatesse Django gruppidesse. Seega töötavad tavapärased Django `Group` ja `Permission` kontrollid paralleelselt liikmesusepõhise ressursiõigusega, kuid tenantide vahelist pääsu ei saa globaalne grupp anda.

--- a/django_backend/api/middleware.py
+++ b/django_backend/api/middleware.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import logging
+from time import monotonic
 
 from config.observability import reset_correlation_id, safe_correlation_id, set_correlation_id
+from config.prometheus import observe_http_request
 
 logger = logging.getLogger(__name__)
 
@@ -24,12 +26,18 @@ class TraceContextMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
+        started_at = monotonic()
         correlation_id = safe_correlation_id(request.headers.get(self.header_name))
         correlation_token = set_correlation_id(correlation_id)
         request.correlation_id = correlation_id
         try:
             response = self.get_response(request)
             response[self.header_name] = correlation_id
+            observe_http_request(
+                request,
+                status_code=response.status_code,
+                duration_seconds=monotonic() - started_at,
+            )
             logger.info(
                 "api.request.completed",
                 extra={
@@ -40,6 +48,7 @@ class TraceContextMiddleware:
             )
             return response
         except Exception:
+            observe_http_request(request, status_code=500, duration_seconds=monotonic() - started_at)
             logger.error(
                 "api.request.unhandled_error",
                 extra={"http_method": request.method, "path": request.path},

--- a/django_backend/api/tests_metrics.py
+++ b/django_backend/api/tests_metrics.py
@@ -1,0 +1,70 @@
+"""Regression tests for the bounded Prometheus metrics endpoint and collectors."""
+
+from __future__ import annotations
+
+import re
+from types import SimpleNamespace
+
+from django.test import TestCase, override_settings
+from django.urls import ResolverMatch
+from django.utils import timezone
+from prometheus_client import generate_latest
+
+from forestry.models import DataSyncRun
+from config.prometheus import stable_route, stable_source_name, stable_task_name
+
+
+class PrometheusEndpointTests(TestCase):
+    @override_settings(FORESTIQ_METRICS_BEARER_TOKEN="metrics-test-token")
+    def test_metrics_endpoint_requires_configured_bearer_token(self):
+        denied = self.client.get("/metrics")
+        allowed = self.client.get("/metrics", HTTP_AUTHORIZATION="Bearer metrics-test-token")
+
+        self.assertEqual(denied.status_code, 403)
+        self.assertEqual(allowed.status_code, 200)
+        self.assertIn(b"forestiq_http_requests_total", allowed.content)
+        self.assertIn(b"forestiq_celery_tasks_total", allowed.content)
+
+    def test_collector_exports_success_age_failure_streak_backlog_and_cursor_lag(self):
+        success = DataSyncRun.objects.create(
+            source="celery:metsaregister-cql-delta",
+            status=DataSyncRun.Status.SUCCESS,
+            finished_at=timezone.now(),
+            lag_seconds=120,
+        )
+        DataSyncRun.objects.create(
+            source="celery:metsaregister-cql-delta",
+            status=DataSyncRun.Status.FAILED,
+            finished_at=timezone.now(),
+        )
+        DataSyncRun.objects.create(source="celery:metsaregister-cql-delta", status=DataSyncRun.Status.QUEUED)
+
+        payload = generate_latest().decode("utf-8")
+
+        self.assertRegex(payload, r'forestiq_sync_last_success_timestamp_seconds\{source="metsaregister"\} [1-9]')
+        self.assertIn('forestiq_sync_failure_streak{source="metsaregister"} 1.0', payload)
+        self.assertIn('forestiq_sync_backlog_runs{source="metsaregister"} 1.0', payload)
+        self.assertIn('forestiq_sync_cursor_lag_seconds{source="metsaregister"} 120.0', payload)
+        self.assertIsNotNone(success.id)
+
+
+class PrometheusCardinalityTests(TestCase):
+    def test_route_source_and_task_labels_exclude_dynamic_identifiers(self):
+        request = SimpleNamespace(
+            resolver_match=ResolverMatch(
+                func=lambda _request: None,
+                args=(),
+                kwargs={},
+                url_name="cadastre-sync",
+                app_names=[],
+                namespaces=[],
+                route="api/services/admin/cadastres/<str:cadastre_id>/sync",
+            )
+        )
+
+        self.assertEqual(stable_route(request), "api/services/admin/cadastres/<str:cadastre_id>/sync")
+        self.assertEqual(stable_source_name("celery:metsaregister-cql-delta"), "metsaregister")
+        self.assertEqual(stable_source_name("retry:api:79601:001:9999"), "retry")
+        self.assertEqual(stable_task_name("forestry.tasks.run_cadastre_sync"), "cadastre_sync")
+        self.assertEqual(stable_task_name("external.task.with.arbitrary.id"), "other")
+        self.assertNotRegex(stable_route(request), re.compile(r"79601|9999"))

--- a/django_backend/api/tests_observability.py
+++ b/django_backend/api/tests_observability.py
@@ -21,6 +21,7 @@ from config.observability import (
     reset_correlation_id,
     set_correlation_id,
 )
+from config.prometheus import CELERY_TASKS
 
 
 class TraceContextMiddlewareTests(SimpleTestCase):
@@ -89,6 +90,14 @@ class CeleryTracePropagationTests(SimpleTestCase):
         clear_task_correlation_id(task_id="celery-01", task=task, state="SUCCESS")
 
         self.assertEqual(current_correlation_id(), "")
+        samples = CELERY_TASKS.collect()[0].samples
+        self.assertTrue(
+            any(
+                sample.name == "forestiq_celery_tasks_total"
+                and sample.labels == {"task": "cadastre_sync", "state": "SUCCESS"}
+                for sample in samples
+            )
+        )
 
     def test_inline_task_preserves_active_request_trace_when_no_header_exists(self):
         request_token = set_correlation_id("trace-inline-request-01")

--- a/django_backend/config/celery.py
+++ b/django_backend/config/celery.py
@@ -14,6 +14,7 @@ from config.observability import (
     safe_correlation_id,
     set_correlation_id,
 )
+from config.prometheus import begin_task_observation, observe_task_completion
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
 
@@ -40,6 +41,7 @@ def bind_task_correlation_id(task_id=None, task=None, **_kwargs) -> None:
     correlation_id = headers.get("correlation_id") or current_correlation_id() or safe_correlation_id(None)
     correlation_token = set_correlation_id(safe_correlation_id(correlation_id))
     task.request._forestiq_correlation_token = correlation_token
+    begin_task_observation(task)
     logger.info("celery.task.started", extra={"task_name": task.name, "celery_task_id": task_id})
 
 
@@ -47,6 +49,7 @@ def bind_task_correlation_id(task_id=None, task=None, **_kwargs) -> None:
 def clear_task_correlation_id(task_id=None, task=None, state=None, **_kwargs) -> None:
     """Log completion and always clear worker-local trace state for the next task."""
 
+    observe_task_completion(task, state=state)
     logger.info(
         "celery.task.finished",
         extra={"task_name": task.name, "celery_task_id": task_id, "task_state": state},

--- a/django_backend/config/metrics_views.py
+++ b/django_backend/config/metrics_views.py
@@ -1,0 +1,18 @@
+"""Prometheus scrape endpoint for the ForestIQ Django process."""
+
+from __future__ import annotations
+
+from django.conf import settings
+from django.http import HttpResponse, HttpResponseForbidden
+from django.views.decorators.http import require_GET
+from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
+
+
+@require_GET
+def prometheus_metrics(request):
+    """Expose the process registry, optionally protected by a fixed scrape token."""
+
+    token = settings.FORESTIQ_METRICS_BEARER_TOKEN
+    if token and request.headers.get("Authorization") != f"Bearer {token}":
+        return HttpResponseForbidden("Metrics authentication required.")
+    return HttpResponse(generate_latest(), content_type=CONTENT_TYPE_LATEST)

--- a/django_backend/config/prometheus.py
+++ b/django_backend/config/prometheus.py
@@ -1,0 +1,195 @@
+"""Low-cardinality Prometheus instrumentation for ForestIQ operations."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Iterable
+from time import monotonic
+
+from django.db import DatabaseError
+from prometheus_client import Counter, Histogram, REGISTRY
+from prometheus_client.core import GaugeMetricFamily
+
+
+HTTP_REQUESTS = Counter(
+    "forestiq_http_requests_total",
+    "Completed HTTP requests by stable route, method and status class.",
+    ("method", "route", "status_class"),
+)
+HTTP_REQUEST_DURATION = Histogram(
+    "forestiq_http_request_duration_seconds",
+    "Completed HTTP request duration by stable route and method.",
+    ("method", "route"),
+)
+HTTP_ERRORS = Counter(
+    "forestiq_http_errors_total",
+    "Completed HTTP requests with an error status by stable route and status class.",
+    ("route", "status_class"),
+)
+CELERY_TASKS = Counter(
+    "forestiq_celery_tasks_total",
+    "Completed Celery tasks by stable task group and result state.",
+    ("task", "state"),
+)
+CELERY_TASK_DURATION = Histogram(
+    "forestiq_celery_task_duration_seconds",
+    "Completed Celery task duration by stable task group.",
+    ("task",),
+)
+
+
+def stable_route(request) -> str:
+    """Return Django's route template, never a request path containing object IDs."""
+
+    resolver_match = getattr(request, "resolver_match", None)
+    route = getattr(resolver_match, "route", "") if resolver_match else ""
+    return route or "unmatched"
+
+
+def stable_task_name(task_name: str | None) -> str:
+    """Collapse implementation names into a bounded set of task labels."""
+
+    name = task_name or ""
+    if name.endswith("run_cadastre_sync"):
+        return "cadastre_sync"
+    if name.endswith("run_metsaregister_delta_check"):
+        return "metsaregister_delta"
+    if name.endswith("run_parimus_official_notice_import"):
+        return "parimus_notices"
+    if name.endswith("enqueue_portfolio_sync"):
+        return "portfolio_dispatch"
+    if name.endswith("enqueue_all_organizations_portfolio_sync"):
+        return "portfolio_beat"
+    if name.endswith("enqueue_all_organizations_metsaregister_delta_check"):
+        return "metsaregister_delta_beat"
+    if name.endswith("enqueue_all_organizations_parimus_official_notice_import"):
+        return "parimus_notices_beat"
+    return "other"
+
+
+def stable_source_name(source: str | None) -> str:
+    """Map audit sources to bounded labels and explicitly reject dynamic identifiers."""
+
+    value = (source or "").lower()
+    if "metsaregister" in value:
+        return "metsaregister"
+    if "parimus" in value:
+        return "parimus"
+    if "forestek" in value:
+        return "forestek"
+    if "cadastre" in value or value in {"api", "daily", "recovery", "all"}:
+        return "cadastre"
+    if value.startswith("retry:"):
+        return "retry"
+    if value.startswith("cli:"):
+        return "cli"
+    return "other"
+
+
+def observe_http_request(request, *, status_code: int, duration_seconds: float) -> None:
+    """Record an HTTP outcome without request-specific labels."""
+
+    route = stable_route(request)
+    method = request.method.upper()
+    status_class = f"{status_code // 100}xx"
+    HTTP_REQUESTS.labels(method=method, route=route, status_class=status_class).inc()
+    HTTP_REQUEST_DURATION.labels(method=method, route=route).observe(duration_seconds)
+    if status_code >= 400:
+        HTTP_ERRORS.labels(route=route, status_class=status_class).inc()
+
+
+def begin_task_observation(task) -> float:
+    """Capture a monotonic start time on the worker-local task request."""
+
+    started_at = monotonic()
+    task.request._forestiq_metrics_started_at = started_at
+    return started_at
+
+
+def observe_task_completion(task, *, state: str | None) -> None:
+    """Record task duration and result using a bounded task-name label."""
+
+    task_name = stable_task_name(getattr(task, "name", ""))
+    task_state = (state or "UNKNOWN").upper()
+    started_at = getattr(task.request, "_forestiq_metrics_started_at", None)
+    if started_at is not None:
+        CELERY_TASK_DURATION.labels(task=task_name).observe(max(0.0, monotonic() - started_at))
+        delattr(task.request, "_forestiq_metrics_started_at")
+    CELERY_TASKS.labels(task=task_name, state=task_state).inc()
+
+
+class IntegrationRunCollector:
+    """Expose durable sync audit health as scrape-time Prometheus gauges."""
+
+    def describe(self) -> Iterable[GaugeMetricFamily]:
+        """Avoid querying Django models while the process registry is still starting."""
+
+        return []
+
+    def collect(self) -> Iterable[GaugeMetricFamily]:
+        latest_success = GaugeMetricFamily(
+            "forestiq_sync_last_success_timestamp_seconds",
+            "Unix timestamp of the latest successful synchronization by source group.",
+            labels=("source",),
+        )
+        failure_streak = GaugeMetricFamily(
+            "forestiq_sync_failure_streak",
+            "Consecutive terminal non-success synchronization runs by source group.",
+            labels=("source",),
+        )
+        backlog = GaugeMetricFamily(
+            "forestiq_sync_backlog_runs",
+            "Queued or running synchronization audit rows by source group.",
+            labels=("source",),
+        )
+        cursor_lag = GaugeMetricFamily(
+            "forestiq_sync_cursor_lag_seconds",
+            "Latest recorded synchronization cursor lag by source group.",
+            labels=("source",),
+        )
+        try:
+            from forestry.models import DataSyncRun
+
+            records = DataSyncRun.objects.order_by("source", "-id").values(
+                "source", "status", "finished_at", "lag_seconds"
+            )
+            grouped: dict[str, list[dict]] = defaultdict(list)
+            for record in records.iterator():
+                grouped[stable_source_name(record["source"])].append(record)
+        except DatabaseError:
+            grouped = {}
+
+        for source, records_for_source in grouped.items():
+            successful = next(
+                (record for record in records_for_source if record["status"] == "SUCCESS" and record["finished_at"]),
+                None,
+            )
+            if successful:
+                latest_success.add_metric([source], successful["finished_at"].timestamp())
+
+            streak = 0
+            for record in records_for_source:
+                if record["status"] == "SUCCESS":
+                    break
+                if record["status"] in {"FAILED", "PARTIAL"}:
+                    streak += 1
+            failure_streak.add_metric([source], streak)
+
+            queued_or_running = sum(1 for record in records_for_source if record["status"] in {"QUEUED", "RUNNING"})
+            backlog.add_metric([source], queued_or_running)
+
+            latest_with_lag = next((record for record in records_for_source if record["lag_seconds"] is not None), None)
+            if latest_with_lag:
+                cursor_lag.add_metric([source], latest_with_lag["lag_seconds"])
+
+        yield latest_success
+        yield failure_streak
+        yield backlog
+        yield cursor_lag
+
+
+try:
+    REGISTRY.register(IntegrationRunCollector())
+except ValueError:
+    # Django autoreload can import this module twice in development; retain one collector.
+    pass

--- a/django_backend/config/settings.py
+++ b/django_backend/config/settings.py
@@ -233,6 +233,7 @@ CELERY_BEAT_SCHEDULE = {
 FORESTIQ_TASKS_INLINE = env_bool("FORESTIQ_TASKS_INLINE", False)
 FORESTIQ_SYNC_HTTP_TIMEOUT_SECONDS = int(os.getenv("FORESTIQ_SYNC_HTTP_TIMEOUT_SECONDS", "30"))
 FORESTIQ_SYNC_RUN_MAX_RETRIES = int(os.getenv("FORESTIQ_SYNC_RUN_MAX_RETRIES", "3"))
+FORESTIQ_METRICS_BEARER_TOKEN = os.getenv("FORESTIQ_METRICS_BEARER_TOKEN", "")
 FORESTIQ_SYNC_USER_AGENT = os.getenv("FORESTIQ_SYNC_USER_AGENT", "ForestIQ data synchronizer/1.0")
 # WFS imports are bounded before parsing or persistence to avoid uncontrolled retries,
 # provider throttling and oversized responses in scheduled synchronization work.

--- a/django_backend/config/urls.py
+++ b/django_backend/config/urls.py
@@ -6,7 +6,10 @@ from django.contrib import admin
 from django.urls import include, path
 from drf_spectacular.views import SpectacularAPIView
 
+from .metrics_views import prometheus_metrics
+
 urlpatterns = [
+    path("metrics", prometheus_metrics, name="prometheus-metrics"),
     path("django-admin/", admin.site.urls),
     path(
         "api/v1/schema/",

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ redis>=5.0,<6.0
 openpyxl>=3.1,<3.2
 requests>=2.32,<3.0
 drf-spectacular==0.28.0
+prometheus-client==0.26.0


### PR DESCRIPTION
## Kokkuvõte

Rakendab issue #48: Prometheuse mõõdikud API päringute, Celery tööde ja `DataSyncRun` auditi töökindluse jälgimiseks.

## Muudatused

- Lisab standardses Prometheuse tekstvormingus `GET /metrics` ekspordivaate koos valikulise `FORESTIQ_METRICS_BEARER_TOKEN` kaitsega.
- Mõõdab API päringute kestust, koguarvu ja vigu stabiilsete `method`, Django route-template’i ning HTTP staatuseklassi siltidega.
- Mõõdab Celery tööde kestust ja tulemust fikseeritud taski-rühma sildiga.
- Lisab scrape-ajal `DataSyncRun` auditist tuletatavad mõõdikud: viimase edukuse timestamp, järjestikune tõrkeseeria, queued/running backlog ning viimane cursor lag.
- Normaliseerib kõik mõõdikute sildid piiratud allika-, töö- ja marsruudiloendiks, nii et neisse ei satu kasutaja-, katastri-, correlation- ega taski ID-sid.
- Lisab scrape-tokeni dokumentatsiooni ning regressioonitestid HTTP/Celery instrumendi, kardinaalsuspiiride ja auditikollektori jaoks.

## Kontroll

Läbisid lokaalsed observability sihttestid, Django süsteemikontroll ja süntaksikontroll. Testibaasi SQLite-režiim ei toeta projekti olemasolevaid GeoDjango PostGIS-migratsioone; täielik testsuit käivitub Quality Gate’i päris PostGIS-i keskkonnas.

Closes #48