### PR TITLE
[QA-02] Lisa PostGISi, Redise ja Celery integratsioonitestid

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -85,7 +85,7 @@ jobs:
           diff --unified=3 ../api_contracts/openapi-v1.yaml ../api_contracts/openapi-v1.generated.yaml
           rm ../api_contracts/openapi-v1.generated.yaml
 
-      - name: Run Django test suite
+      - name: Run Django test suite, including PostGIS, Redis and Celery integrations
         working-directory: django_backend
         run: python manage.py test --verbosity 2
 

--- a/django_backend/api/tests_api_contract.py
+++ b/django_backend/api/tests_api_contract.py
@@ -26,3 +26,6 @@ class ApiV1CompatibilityTests(SimpleTestCase):
         self.assertEqual(schema["openapi"], "3.0.3")
         self.assertEqual(schema["info"]["version"], "1.0.0")
         self.assertIn("/api/v1/services/status", schema["paths"])
+        retry_path = "/api/v1/services/admin/sync-runs/{run_id}/retry"
+        self.assertIn(retry_path, schema["paths"])
+        self.assertIn("post", schema["paths"][retry_path])

--- a/django_backend/forestry/tests_integration.py
+++ b/django_backend/forestry/tests_integration.py
@@ -1,0 +1,57 @@
+"""Integration tests that must run against the Quality Gate PostGIS and Redis services."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from celery.contrib.testing.worker import start_worker
+from django.contrib.gis.geos import MultiPolygon, Polygon
+from django.test import SimpleTestCase, TestCase
+
+from config.celery import app
+from forestry.models import Cadastre
+from forestry.services.single_flight import SingleFlightLock
+
+
+@app.task(name="forestiq.tests.integration_echo")
+def integration_echo(value: str) -> str:
+    """Minimal task used to verify broker-to-worker-to-result-backend delivery."""
+
+    return value
+
+
+class PostGISSpatialIntegrationTests(TestCase):
+    def test_boundary_intersection_uses_the_postgis_geometry_backend(self):
+        boundary = MultiPolygon(
+            Polygon(((500000, 6400000), (500100, 6400000), (500100, 6400100), (500000, 6400100), (500000, 6400000))),
+            srid=3301,
+        )
+        Cadastre.objects.create(id="QA02:POSTGIS:001", boundary=boundary)
+        probe = Polygon(((500050, 6400050), (500150, 6400050), (500150, 6400150), (500050, 6400150), (500050, 6400050)), srid=3301)
+
+        matches = Cadastre.objects.filter(boundary__intersects=probe).values_list("id", flat=True)
+
+        self.assertEqual(list(matches), ["QA02:POSTGIS:001"])
+
+
+class RedisSingleFlightIntegrationTests(SimpleTestCase):
+    def test_redis_enforces_one_token_owned_sync_lock_at_a_time(self):
+        scope = f"qa02-{uuid4().hex}"
+        first = SingleFlightLock.for_sync("qa02-integration", "quality-gate", scope)
+        second = SingleFlightLock.for_sync("qa02-integration", "quality-gate", scope)
+
+        self.assertTrue(first.acquire())
+        self.assertFalse(second.acquire())
+        self.assertEqual(first.client.get(first.key), first.token)
+        first.release()
+        self.assertTrue(second.acquire())
+        second.release()
+
+
+class CeleryRedisIntegrationTests(SimpleTestCase):
+    def test_real_celery_worker_round_trip_uses_redis_broker_and_result_backend(self):
+        value = f"qa02-{uuid4().hex}"
+
+        with start_worker(app, pool="solo", concurrency=1, perform_ping_check=False, loglevel="WARNING"):
+            result = integration_echo.delay(value)
+            self.assertEqual(result.get(timeout=15), value)


### PR DESCRIPTION
## Kokkuvõte

Rakendab issue #53: Quality Gate’i päris PostGIS-i ja Redise teenustega kontrollitavad integratsioonitestid ning kriitilise API v1 taastamislepingu kontroll.

## Muudatused

- Lisab PostGIS-i ruumilise `boundary__intersects` päringu integreerimistesti päris GeoDjango/PostGIS-i andmebaasile.
- Lisab Redise single-flight luku testi, mis kontrollib tokeniga omandamist, konkurentse omandamise blokeerimist ja turvalist vabastamist.
- Lisab päris Celery worker round-trip testi, mis saadab töö Redise brokerisse, töötleb selle `solo` workeriga ja loeb tulemuse Redis tulemuse-backendist.
- Täiendab API v1 OpenAPI lepingutesti kriitilise sünkroonimisjooksu retry endpointi olemasolu ning POST-operatsiooni kontrolliga.
- Nimetab Quality Gate’i Django testi sammu selgelt PostGIS-i, Redise ja Celery integratsioone hõlmavaks.

## Kohalik kontroll

Läbisid Django süsteemikontroll, süntaksikontroll ning API v1 lepingutest. Kohaliku SQLite testirežiimi täistest ei saa käivituda projekti olemasoleva GeoDjango PostGIS-migratsiooni tõttu; PR Quality Gate kasutab päris PostGIS-i ja Redis’t.

Closes #53