### PR TITLE
[OPS-03] Erista liveness, readiness ja integratsioonide health

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,8 @@ FORESTIQ_SINGLE_FLIGHT_LOCK_TTL_SECONDS=900
 FORESTIQ_SYNC_RUN_MAX_RETRIES=3
 # Valikuline Prometheuse scrape-token. Tootmises kasuta tugevat eraldi väärtust.
 FORESTIQ_METRICS_BEARER_TOKEN=
+# Maksimaalne aeg sekundites pärast viimast edukat sünkroonimist enne integratsiooni stale-märgendit.
+FORESTIQ_INTEGRATION_STALE_AFTER_SECONDS=28800
 
 # Bounded public WFS import policy: payload safety, retry/backoff and provider pacing.
 FORESTIQ_WFS_MAX_FEATURES=10000

--- a/README.md
+++ b/README.md
@@ -224,6 +224,12 @@ Django protsess ekspordib Prometheuse vormingus mõõdikud aadressil `GET /metri
 
 Tootmises määra `FORESTIQ_METRICS_BEARER_TOKEN` tugevale eraldi saladusele ja anna Prometheusele scrape’iks päis `Authorization: Bearer <token>`. Tühja väärtuse korral jääb endpoint arendus- ja sisemise võrgu kasutuseks avatuks.
 
+### Liveness, readiness ja SLO-alarmid (OPS-03)
+
+`GET /api/health/live` kinnitab ainult Django protsessi elusolekut ega pöördu andmebaasi, Redise ega välise integratsiooni poole; Render kasutab seda protsessi restart’i tervisekontrollina. `GET /api/health/ready` kontrollib enne liikluse lubamist PostgreSQL-i ja Redise ühendust. Administraatori `GET /api/services/admin/integrations/health` kuvab eraldi püsivast `DataSyncRun` auditist tuletatud integratsioonide värskuse, tõrkeseeria, backlog’i ja cursor lag’i, ilma välis-API-sid probe’imata.
+
+Prometheuse alarmifail asub `observability/prometheus/forestiq-alerts.yml`. See sisaldab hoiatuse aegunud sünkroonimisandmete, kolme järjestikuse tõrke, kasvava sünkroonimisbacklog’i ja üle viieprotsendise API veamäära kohta. Paigalda fail Prometheuse `rule_files` konfiguratsiooni ning suuna teavitused Alertmanagerisse. `FORESTIQ_INTEGRATION_STALE_AFTER_SECONDS` määrab health-vaate värskusläve; alarmireegli vaikimisi lävi on kaheksa tundi.
+
 ## Turve
 
 Django API kasutab organisatsiooniga seotud sisemist Bearer JWT-d. Reacti töölaud kasutab tootmises Keycloak’i Authorization Code + PKCE voogu; kohalik parooli/TOTP voog on ainult arenduseks. Õigused `ADMIN`, `OWNER_PROFILE`, `ASSIGNED_OWNERS`, `PHONES` ja `EVALUATION` tulenevad aktiivse organisatsiooniliikmesuse rollidest ning pärandõigused sünkroniseeritakse endiselt vastavatesse Django gruppidesse. Seega töötavad tavapärased Django `Group` ja `Permission` kontrollid paralleelselt liikmesusepõhise ressursiõigusega, kuid tenantide vahelist pääsu ei saa globaalne grupp anda.

--- a/api_contracts/openapi-v1.yaml
+++ b/api_contracts/openapi-v1.yaml
@@ -4,6 +4,29 @@ info:
   version: 1.0.0
   description: Versioned compatibility API for the ForestIQ Django rewrite.
 paths:
+  /api/v1/health/live:
+    get:
+      operationId: health_live_retrieve
+      description: Report only whether this Django process can answer a request.
+      tags:
+      - health
+      security:
+      - {}
+      responses:
+        '200':
+          description: No response body
+  /api/v1/health/ready:
+    get:
+      operationId: health_ready_retrieve
+      description: Report whether local serving dependencies (database and broker)
+        are usable.
+      tags:
+      - health
+      security:
+      - {}
+      responses:
+        '200':
+          description: No response body
   /api/v1/oidc/config:
     get:
       operationId: oidc_config_retrieve
@@ -120,6 +143,16 @@ paths:
         schema:
           type: string
         required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/admin/integrations/health:
+    get:
+      operationId: services_admin_integrations_health_retrieve
+      description: Report data freshness and sync health from the audit trail, never
+        by probing providers.
       tags:
       - services
       responses:

--- a/django_backend/api/health.py
+++ b/django_backend/api/health.py
@@ -1,0 +1,118 @@
+"""Operational health endpoints with explicitly separated dependency scopes."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import timedelta
+
+import redis
+from django.conf import settings
+from django.db import connection
+from django.db.utils import DatabaseError
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.decorators import api_view, authentication_classes, permission_classes
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+
+from api.permissions import IsAdmin
+from forestry.models import DataSyncRun
+from config.prometheus import stable_source_name
+
+
+@api_view(["GET"])
+@authentication_classes([])
+@permission_classes([AllowAny])
+def liveness(_request):
+    """Report only whether this Django process can answer a request."""
+
+    return Response({"status": "OK", "check": "liveness"})
+
+
+def _database_ready() -> tuple[bool, str | None]:
+    try:
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT 1")
+            cursor.fetchone()
+    except DatabaseError:
+        return False, "unavailable"
+    return True, None
+
+
+def _redis_ready() -> tuple[bool, str | None]:
+    try:
+        redis.from_url(settings.CELERY_BROKER_URL, socket_connect_timeout=1, socket_timeout=1).ping()
+    except redis.RedisError:
+        return False, "unavailable"
+    return True, None
+
+
+@api_view(["GET"])
+@authentication_classes([])
+@permission_classes([AllowAny])
+def readiness(_request):
+    """Report whether local serving dependencies (database and broker) are usable."""
+
+    database_ok, database_error = _database_ready()
+    redis_ok, redis_error = _redis_ready()
+    dependencies = {
+        "database": {"status": "OK" if database_ok else "ERROR"},
+        "redis": {"status": "OK" if redis_ok else "ERROR"},
+    }
+    if database_error:
+        dependencies["database"]["reason"] = database_error
+    if redis_error:
+        dependencies["redis"]["reason"] = redis_error
+    healthy = database_ok and redis_ok
+    return Response(
+        {"status": "OK" if healthy else "ERROR", "check": "readiness", "dependencies": dependencies},
+        status=status.HTTP_200_OK if healthy else status.HTTP_503_SERVICE_UNAVAILABLE,
+    )
+
+
+def _integration_payload(records: list[dict]) -> dict:
+    """Build a bounded per-source state from durable audit rows without external calls."""
+
+    latest = records[0]
+    latest_success = next(
+        (record for record in records if record["status"] == DataSyncRun.Status.SUCCESS and record["finished_at"]),
+        None,
+    )
+    failure_streak = 0
+    for record in records:
+        if record["status"] == DataSyncRun.Status.SUCCESS:
+            break
+        if record["status"] in {DataSyncRun.Status.FAILED, DataSyncRun.Status.PARTIAL}:
+            failure_streak += 1
+    stale_after = timedelta(seconds=settings.FORESTIQ_INTEGRATION_STALE_AFTER_SECONDS)
+    stale = not latest_success or latest_success["finished_at"] < timezone.now() - stale_after
+    health = "OK" if not stale and failure_streak == 0 else "DEGRADED"
+    return {
+        "source": stable_source_name(latest["source"]),
+        "health": health,
+        "lastStatus": latest["status"],
+        "lastSuccessAt": latest_success["finished_at"].isoformat() if latest_success else None,
+        "failureStreak": failure_streak,
+        "backlogSize": sum(1 for record in records if record["status"] in {DataSyncRun.Status.QUEUED, DataSyncRun.Status.RUNNING}),
+        "lagSeconds": next((record["lag_seconds"] for record in records if record["lag_seconds"] is not None), None),
+    }
+
+
+@api_view(["GET"])
+@permission_classes([IsAdmin])
+def integrations_health(_request):
+    """Report data freshness and sync health from the audit trail, never by probing providers."""
+
+    grouped: dict[str, list[dict]] = defaultdict(list)
+    for record in DataSyncRun.objects.order_by("source", "-id").values("source", "status", "finished_at", "lag_seconds").iterator():
+        grouped[stable_source_name(record["source"])].append(record)
+    integrations = [_integration_payload(records) for _, records in sorted(grouped.items())]
+    degraded = [item["source"] for item in integrations if item["health"] != "OK"]
+    return Response(
+        {
+            "status": "DEGRADED" if degraded else "OK",
+            "check": "integrations",
+            "integrations": integrations,
+            "degradedSources": degraded,
+        }
+    )

--- a/django_backend/api/tests_health.py
+++ b/django_backend/api/tests_health.py
@@ -1,0 +1,106 @@
+"""Regression tests for distinct operational health and SLO alert surfaces."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+import yaml
+from django.test import SimpleTestCase, override_settings
+from django.utils import timezone
+
+from api.health import _integration_payload
+from forestry.models import DataSyncRun
+
+
+class HealthEndpointTests(SimpleTestCase):
+    def test_liveness_is_public_and_never_checks_dependencies(self):
+        with patch("api.health._database_ready") as database_check, patch("api.health._redis_ready") as redis_check:
+            response = self.client.get("/api/health/live")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, {"status": "OK", "check": "liveness"})
+        database_check.assert_not_called()
+        redis_check.assert_not_called()
+
+    @patch("api.health._redis_ready", return_value=(True, None))
+    @patch("api.health._database_ready", return_value=(True, None))
+    def test_readiness_requires_database_and_redis(self, database_check, redis_check):
+        response = self.client.get("/api/health/ready")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["dependencies"]["database"]["status"], "OK")
+        self.assertEqual(response.data["dependencies"]["redis"]["status"], "OK")
+        database_check.assert_called_once()
+        redis_check.assert_called_once()
+
+    @patch("api.health._redis_ready", return_value=(False, "unavailable"))
+    @patch("api.health._database_ready", return_value=(True, None))
+    def test_readiness_returns_503_when_a_dependency_is_unavailable(self, _database_check, _redis_check):
+        response = self.client.get("/api/health/ready")
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.data["status"], "ERROR")
+        self.assertEqual(response.data["dependencies"]["redis"], {"status": "ERROR", "reason": "unavailable"})
+
+
+class IntegrationHealthTests(SimpleTestCase):
+    @override_settings(FORESTIQ_INTEGRATION_STALE_AFTER_SECONDS=3600)
+    def test_recent_success_is_healthy_and_terminal_failure_streak_is_degraded(self):
+        recent_success = {
+            "source": "celery:metsaregister-cql-delta",
+            "status": DataSyncRun.Status.SUCCESS,
+            "finished_at": timezone.now() - timedelta(minutes=5),
+            "lag_seconds": 120,
+        }
+        healthy = _integration_payload([recent_success])
+        failure = {
+            "source": "celery:metsaregister-cql-delta",
+            "status": DataSyncRun.Status.FAILED,
+            "finished_at": timezone.now(),
+            "lag_seconds": None,
+        }
+        degraded = _integration_payload([failure, recent_success])
+
+        self.assertEqual(healthy["health"], "OK")
+        self.assertEqual(healthy["lagSeconds"], 120)
+        self.assertEqual(degraded["health"], "DEGRADED")
+        self.assertEqual(degraded["failureStreak"], 1)
+
+    @override_settings(FORESTIQ_INTEGRATION_STALE_AFTER_SECONDS=60)
+    def test_old_success_is_reported_as_degraded_without_calling_the_provider(self):
+        stale = _integration_payload(
+            [
+                {
+                    "source": "celery:parimus-official-notices",
+                    "status": DataSyncRun.Status.SUCCESS,
+                    "finished_at": timezone.now() - timedelta(minutes=2),
+                    "lag_seconds": None,
+                }
+            ]
+        )
+
+        self.assertEqual(stale["source"], "parimus")
+        self.assertEqual(stale["health"], "DEGRADED")
+
+
+class SloAlertRuleTests(SimpleTestCase):
+    def test_rule_file_contains_all_required_operational_alerts(self):
+        rule_file = Path(__file__).resolve().parents[2] / "observability" / "prometheus" / "forestiq-alerts.yml"
+        payload = yaml.safe_load(rule_file.read_text(encoding="utf-8"))
+        rules = {rule["alert"]: rule for group in payload["groups"] for rule in group["rules"]}
+
+        self.assertEqual(
+            set(rules),
+            {
+                "ForestIQIntegrationDataStale",
+                "ForestIQIntegrationFailureStreak",
+                "ForestIQSyncBacklogGrowing",
+                "ForestIQApiErrorRatioHigh",
+            },
+        )
+        self.assertIn("forestiq_sync_last_success_timestamp_seconds", rules["ForestIQIntegrationDataStale"]["expr"])
+        self.assertIn("forestiq_sync_failure_streak", rules["ForestIQIntegrationFailureStreak"]["expr"])
+        self.assertIn("forestiq_sync_backlog_runs", rules["ForestIQSyncBacklogGrowing"]["expr"])
+        self.assertIn("forestiq_http_errors_total", rules["ForestIQApiErrorRatioHigh"]["expr"])

--- a/django_backend/api/urls.py
+++ b/django_backend/api/urls.py
@@ -2,7 +2,7 @@
 
 from django.urls import path
 
-from . import auth, parity, views
+from . import auth, health, parity, views
 
 urlpatterns = [
     path("oidc/config", auth.oidc_configuration),
@@ -12,6 +12,9 @@ urlpatterns = [
     path("services/token-refresh", auth.refresh_token),
     path("services/change-my-password", auth.change_my_password),
     path("services/status", views.service_status),
+    path("health/live", health.liveness),
+    path("health/ready", health.readiness),
+    path("services/admin/integrations/health", health.integrations_health),
     path("services/admin/users", views.admin_users),
     path("services/admin/users/<str:user_id>", views.admin_user_detail),
     path("services/admin/userstatistics/prep-data", views.user_statistics_prep),

--- a/django_backend/config/settings.py
+++ b/django_backend/config/settings.py
@@ -234,6 +234,7 @@ FORESTIQ_TASKS_INLINE = env_bool("FORESTIQ_TASKS_INLINE", False)
 FORESTIQ_SYNC_HTTP_TIMEOUT_SECONDS = int(os.getenv("FORESTIQ_SYNC_HTTP_TIMEOUT_SECONDS", "30"))
 FORESTIQ_SYNC_RUN_MAX_RETRIES = int(os.getenv("FORESTIQ_SYNC_RUN_MAX_RETRIES", "3"))
 FORESTIQ_METRICS_BEARER_TOKEN = os.getenv("FORESTIQ_METRICS_BEARER_TOKEN", "")
+FORESTIQ_INTEGRATION_STALE_AFTER_SECONDS = int(os.getenv("FORESTIQ_INTEGRATION_STALE_AFTER_SECONDS", "28800"))
 FORESTIQ_SYNC_USER_AGENT = os.getenv("FORESTIQ_SYNC_USER_AGENT", "ForestIQ data synchronizer/1.0")
 # WFS imports are bounded before parsing or persistence to avoid uncontrolled retries,
 # provider throttling and oversized responses in scheduled synchronization work.

--- a/observability/prometheus/forestiq-alerts.yml
+++ b/observability/prometheus/forestiq-alerts.yml
@@ -1,0 +1,42 @@
+groups:
+  - name: forestiq-service-slo
+    rules:
+      - alert: ForestIQIntegrationDataStale
+        expr: time() - forestiq_sync_last_success_timestamp_seconds > 28800
+        for: 30m
+        labels:
+          severity: warning
+          service: forestiq-django
+        annotations:
+          summary: "ForestIQ integration data is stale"
+          description: "{{ $labels.source }} has not completed successfully for more than eight hours."
+
+      - alert: ForestIQIntegrationFailureStreak
+        expr: forestiq_sync_failure_streak >= 3
+        for: 15m
+        labels:
+          severity: critical
+          service: forestiq-django
+        annotations:
+          summary: "ForestIQ integration is repeatedly failing"
+          description: "{{ $labels.source }} has {{ $value }} consecutive terminal non-success runs."
+
+      - alert: ForestIQSyncBacklogGrowing
+        expr: forestiq_sync_backlog_runs >= 10
+        for: 15m
+        labels:
+          severity: warning
+          service: forestiq-django
+        annotations:
+          summary: "ForestIQ synchronization backlog is growing"
+          description: "{{ $labels.source }} has {{ $value }} queued or running audit rows."
+
+      - alert: ForestIQApiErrorRatioHigh
+        expr: sum(rate(forestiq_http_errors_total[5m])) / clamp_min(sum(rate(forestiq_http_requests_total[5m])), 1) > 0.05
+        for: 10m
+        labels:
+          severity: warning
+          service: forestiq-django
+        annotations:
+          summary: "ForestIQ API error ratio is above the SLO"
+          description: "The five-minute API error ratio has exceeded five percent."

--- a/render.yaml
+++ b/render.yaml
@@ -10,7 +10,7 @@ services:
     dockerContext: .
     dockerCommand: gunicorn config.wsgi:application --bind 0.0.0.0:$PORT --workers 3 --access-logfile - --error-logfile -
     preDeployCommand: sh scripts/render-predeploy.sh
-    healthCheckPath: /api/services/status
+    healthCheckPath: /api/health/live
     plan: starter
     autoDeployTrigger: commit
     disk:


### PR DESCRIPTION
## Kokkuvõte

Rakendab issue #50: sõltuvusteta liveness, DB/Redis readiness, auditi-põhine integratsioonide health ja Prometheuse SLO-alarmireeglid.

## Muudatused

- Lisab avaliku `GET /api/health/live` liveness endpointi, mis ei puutu DB, Redise ega väliste integratsioonidega.
- Lisab avaliku `GET /api/health/ready` readiness endpointi, mis kontrollib PostgreSQL-i `SELECT 1` päringuga ja Redise `PING`-iga; sõltuvuse tõrkel tagastab 503.
- Lisab haldusõigusega `GET /api/services/admin/integrations/health` vaate, mis hindab andmete värskust, failure streak’i, backlog’i ja cursor lag’i ainult `DataSyncRun` auditi põhjal ega probe’i välis-API-sid.
- Suunab Renderi protsessitervise sõltuvusteta liveness endpointile.
- Lisab Prometheuse alarmid aegunud andmetele, vähemalt kolmele järjestikusele tõrkele, vähemalt kümnesele backlog’ile ja üle viieprotsendisele API veamäärale.
- Uuendab OpenAPI v1 snapshot’i, keskkonnadokumentatsiooni ja lisab health/SLO regressioonitestid.

## Kontroll

Läbisid health- ja SLO-reeglite testid, API v1 lepingutest, Django süsteemikontroll ning OpenAPI snapshot’i genereerimine.

Closes #50