### PR TITLE
[UX-05] Rakenda route-level rollivalve ja õiguspõhine navigatsioon

### DIFF
--- a/forestiq-ui/client/src/App.tsx
+++ b/forestiq-ui/client/src/App.tsx
@@ -1,22 +1,66 @@
-/** ForestIQ Landscape Desk design: route shell prioritizes operational access and API-authenticated flows. */
-import { Route, Switch, Redirect } from "wouter";
+/** ForestIQ Landscape Desk route shell with authorization-aware navigation guards. */
+import { Redirect, Route, Switch } from "wouter";
 import { lazy, Suspense } from "react";
+
 import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import ErrorBoundary from "@/components/ErrorBoundary";
 import { AuthProvider, useAuth } from "@/contexts/AuthContext";
-import Login from "@/pages/Login";
-import Dashboard from "@/pages/Dashboard";
-import Owners from "@/pages/Owners";
-import OwnerDetail from "@/pages/OwnerDetail";
-import Reminders from "@/pages/Reminders";
-import Messages from "@/pages/Messages";
+import { hasAccess, type AccessRequirement } from "@/lib/authorization";
+import { AccessDenied, AuthenticationRequired } from "@/pages/AccessState";
 import Admin from "@/pages/Admin";
-import { GenericWorkspace, OwnerWorkspace } from "@/pages/Workspaces";
+import Dashboard from "@/pages/Dashboard";
+import Login from "@/pages/Login";
+import Messages from "@/pages/Messages";
+import NotFound from "@/pages/NotFound";
+import OwnerDetail from "@/pages/OwnerDetail";
+import Owners from "@/pages/Owners";
 import { DealsWorkspace, InheritanceWorkspace, IntegrationsWorkspace, OwnerImportWorkspace, SalesWorkspace } from "@/pages/ParityWorkspaces";
+import Reminders from "@/pages/Reminders";
+import { GenericWorkspace, OwnerWorkspace } from "@/pages/Workspaces";
 
 const MapWorkspace = lazy(() => import("@/pages/MapWorkspace"));
 
-function Protected({ children }: { children: React.ReactNode }) { const { user, ready } = useAuth(); if (!ready) return <div className="app-loading">Laadin ForestIQ töölauda…</div>; return user ? <>{children}</> : <Redirect to="/" />; }
-function Routes() { return <Switch><Route path="/" component={Login} /><Route path="/home"><Protected><Dashboard /></Protected></Route><Route path="/owners"><Protected><Owners /></Protected></Route><Route path="/owners/import"><Protected><OwnerImportWorkspace /></Protected></Route><Route path="/owners/:id"><Protected><OwnerDetail /></Protected></Route><Route path="/map"><Protected><Suspense fallback={<div className="app-loading">Laadin kaarditöölauda…</div>}><MapWorkspace /></Suspense></Protected></Route><Route path="/deals"><Protected><DealsWorkspace /></Protected></Route><Route path="/inheritance"><Protected><InheritanceWorkspace /></Protected></Route><Route path="/sales"><Protected><SalesWorkspace /></Protected></Route><Route path="/integrations"><Protected><IntegrationsWorkspace /></Protected></Route><Route path="/workdesk/caller"><Protected><OwnerWorkspace kind="caller" /></Protected></Route><Route path="/workdesk/evaluator"><Protected><OwnerWorkspace kind="evaluator" /></Protected></Route><Route path="/workdesk/admin"><Protected><OwnerWorkspace kind="admin" /></Protected></Route><Route path="/reminders"><Protected><Reminders /></Protected></Route><Route path="/messages"><Protected><Messages /></Protected></Route><Route path="/admin"><Protected><Admin /></Protected></Route><Route path="/contracts"><Protected><GenericWorkspace kind="contracts" /></Protected></Route><Route path="/phones"><Protected><GenericWorkspace kind="phones" /></Protected></Route><Route path="/me"><Protected><GenericWorkspace kind="me" /></Protected></Route><Route path="/reminders-dashboard"><Protected><Reminders /></Protected></Route><Route><Redirect to="/home" /></Route></Switch>; }
-export default function App() { return <ErrorBoundary><AuthProvider><TooltipProvider><Routes /><Toaster position="bottom-right" /></TooltipProvider></AuthProvider></ErrorBoundary>; }
+type ProtectedProps = { children: React.ReactNode; requirement?: AccessRequirement };
+
+function Protected({ children, requirement }: ProtectedProps) {
+  const { user, ready } = useAuth();
+  if (!ready) return <div className="app-loading">Laadin ForestIQ töölauda…</div>;
+  if (!user) return <AuthenticationRequired />;
+  if (!hasAccess(user, requirement)) return <AccessDenied />;
+  return <>{children}</>;
+}
+
+const requirePrivileges = (...anyPrivileges: NonNullable<AccessRequirement["anyPrivileges"]>): AccessRequirement => ({ anyPrivileges });
+
+function Routes() {
+  return (
+    <Switch>
+      <Route path="/" component={Login} />
+      <Route path="/home"><Protected><Dashboard /></Protected></Route>
+      <Route path="/owners"><Protected requirement={requirePrivileges("ADMIN", "OWNER_PROFILE", "ASSIGNED_OWNERS")}><Owners /></Protected></Route>
+      <Route path="/owners/import"><Protected requirement={requirePrivileges("ADMIN", "OWNER_PROFILE", "ASSIGNED_OWNERS")}><OwnerImportWorkspace /></Protected></Route>
+      <Route path="/owners/:id"><Protected requirement={requirePrivileges("ADMIN", "OWNER_PROFILE", "ASSIGNED_OWNERS")}><OwnerDetail /></Protected></Route>
+      <Route path="/map"><Protected requirement={requirePrivileges("ADMIN", "OWNER_PROFILE", "ASSIGNED_OWNERS", "EVALUATION")}><Suspense fallback={<div className="app-loading">Laadin kaarditöölauda…</div>}><MapWorkspace /></Suspense></Protected></Route>
+      <Route path="/deals"><Protected requirement={requirePrivileges("ADMIN", "OWNER_PROFILE", "EVALUATION")}><DealsWorkspace /></Protected></Route>
+      <Route path="/inheritance"><Protected requirement={requirePrivileges("ADMIN", "OWNER_PROFILE", "ASSIGNED_OWNERS")}><InheritanceWorkspace /></Protected></Route>
+      <Route path="/sales"><Protected requirement={requirePrivileges("ADMIN", "OWNER_PROFILE", "ASSIGNED_OWNERS")}><SalesWorkspace /></Protected></Route>
+      <Route path="/integrations"><Protected requirement={requirePrivileges("ADMIN")}><IntegrationsWorkspace /></Protected></Route>
+      <Route path="/workdesk/caller"><Protected requirement={requirePrivileges("ADMIN", "ASSIGNED_OWNERS")}><OwnerWorkspace kind="caller" /></Protected></Route>
+      <Route path="/workdesk/evaluator"><Protected requirement={requirePrivileges("ADMIN", "EVALUATION")}><OwnerWorkspace kind="evaluator" /></Protected></Route>
+      <Route path="/workdesk/admin"><Protected requirement={requirePrivileges("ADMIN")}><OwnerWorkspace kind="admin" /></Protected></Route>
+      <Route path="/reminders"><Protected><Reminders /></Protected></Route>
+      <Route path="/messages"><Protected><Messages /></Protected></Route>
+      <Route path="/admin"><Protected requirement={requirePrivileges("ADMIN")}><Admin /></Protected></Route>
+      <Route path="/contracts"><Protected requirement={requirePrivileges("ADMIN", "OWNER_PROFILE")}><GenericWorkspace kind="contracts" /></Protected></Route>
+      <Route path="/phones"><Protected requirement={requirePrivileges("ADMIN", "PHONES")}><GenericWorkspace kind="phones" /></Protected></Route>
+      <Route path="/me"><Protected><GenericWorkspace kind="me" /></Protected></Route>
+      <Route path="/reminders-dashboard"><Protected><Reminders /></Protected></Route>
+      <Route><NotFound /></Route>
+    </Switch>
+  );
+}
+
+export default function App() {
+  return <ErrorBoundary><AuthProvider><TooltipProvider><Routes /><Toaster position="bottom-right" /></TooltipProvider></AuthProvider></ErrorBoundary>;
+}

--- a/forestiq-ui/client/src/components/AppShell.tsx
+++ b/forestiq-ui/client/src/components/AppShell.tsx
@@ -1,7 +1,33 @@
 /** ForestIQ Landscape Desk design: fixed dark spruce navigation and a spacious operational surface. */
-import { Bell, BookOpenText, ClipboardList, Compass, FileText, LayoutDashboard, LogOut, MessagesSquare, Phone, Settings2, UsersRound, ChevronRight, BadgeEuro, Gavel, Gauge, MapPinned } from "lucide-react";
+import { BadgeEuro, Bell, BookOpenText, ChevronRight, ClipboardList, Compass, FileText, Gauge, Gavel, LayoutDashboard, LogOut, MapPinned, MessagesSquare, Phone, Settings2, UsersRound, type LucideIcon } from "lucide-react";
 import { Link, useLocation } from "wouter";
-import { ForestMark } from "./ForestMark";
+
 import { useAuth } from "@/contexts/AuthContext";
-const navigation = [["Töölaud", "/home", LayoutDashboard], ["Omanikud", "/owners", UsersRound], ["Müügijärjekord", "/sales", ClipboardList], ["Tehingud", "/deals", BadgeEuro], ["Pärimine", "/inheritance", Gavel], ["Kaart", "/map", MapPinned], ["Hindamine", "/workdesk/evaluator", Compass], ["Meeldetuletused", "/reminders", Bell], ["Sõnumid", "/messages", MessagesSquare], ["Lepingud", "/contracts", FileText], ["Kontaktid", "/phones", Phone], ["Import", "/owners/import", FileText], ["Integratsioonid", "/integrations", Gauge], ["Haldus", "/admin", Settings2]] as const;
-export function AppShell({ children, title, eyebrow }: { children: React.ReactNode; title: string; eyebrow?: string }) { const [location] = useLocation(); const { user, logout } = useAuth(); return <div className="app-frame"><aside className="sidebar"><Link href="/home" className="brand"><ForestMark size={42} /><span><strong>Forest</strong><em>IQ</em><small>maastiku töölaud</small></span></Link><nav>{navigation.map(([label, href, Icon]) => <Link key={href} href={href} className={`nav-link ${location.startsWith(href) ? "active" : ""}`}><Icon size={18} /><span>{label}</span><ChevronRight size={14} /></Link>)}</nav><div className="sidebar-foot"><div className="user-card"><div className="avatar">{user?.name?.slice(0, 1) || "?"}</div><div><strong>{user?.name || "Kasutaja"}</strong><span>{user?.id}</span></div></div><button className="logout" onClick={logout}><LogOut size={16} /> Välju</button></div></aside><main className="main-surface"><header className="topbar"><div><p className="eyebrow">{eyebrow || "FORESTIQ / OPERATSIOONID"}</p><h1>{title}</h1></div><div className="topbar-actions"><div className="sync-dot"><span /> API ühendus</div><Link href="/me" className="profile-link"><BookOpenText size={17} /> Minu konto</Link></div></header><div className="page-content">{children}</div></main></div>; }
+import { hasAccess, navigationItems } from "@/lib/authorization";
+
+import { ForestMark } from "./ForestMark";
+
+const navigationIcons: Record<string, LucideIcon> = {
+  "/home": LayoutDashboard,
+  "/owners": UsersRound,
+  "/sales": ClipboardList,
+  "/deals": BadgeEuro,
+  "/inheritance": Gavel,
+  "/map": MapPinned,
+  "/workdesk/evaluator": Compass,
+  "/reminders": Bell,
+  "/messages": MessagesSquare,
+  "/contracts": FileText,
+  "/phones": Phone,
+  "/owners/import": FileText,
+  "/integrations": Gauge,
+  "/admin": Settings2,
+} as const;
+
+export function AppShell({ children, title, eyebrow }: { children: React.ReactNode; title: string; eyebrow?: string }) {
+  const [location] = useLocation();
+  const { user, logout } = useAuth();
+  const visibleNavigation = navigationItems.filter((item) => hasAccess(user, item.requirement));
+
+  return <div className="app-frame"><aside className="sidebar"><Link href="/home" className="brand"><ForestMark size={42} /><span><strong>Forest</strong><em>IQ</em><small>maastiku töölaud</small></span></Link><nav>{visibleNavigation.map(({ label, href }) => { const Icon = navigationIcons[href]; return <Link key={href} href={href} className={`nav-link ${location.startsWith(href) ? "active" : ""}`}><Icon size={18} /><span>{label}</span><ChevronRight size={14} /></Link>; })}</nav><div className="sidebar-foot"><div className="user-card"><div className="avatar">{user?.name?.slice(0, 1) || "?"}</div><div><strong>{user?.name || "Kasutaja"}</strong><span>{user?.id}</span></div></div><button className="logout" onClick={logout}><LogOut size={16} /> Välju</button></div></aside><main className="main-surface"><header className="topbar"><div><p className="eyebrow">{eyebrow || "FORESTIQ / OPERATSIOONID"}</p><h1>{title}</h1></div><div className="topbar-actions"><div className="sync-dot"><span /> API ühendus</div><Link href="/me" className="profile-link"><BookOpenText size={17} /> Minu konto</Link></div></header><div className="page-content">{children}</div></main></div>;
+}

--- a/forestiq-ui/client/src/lib/authorization.test.ts
+++ b/forestiq-ui/client/src/lib/authorization.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { hasAccess, navigationItems, requirementForPath } from "./authorization";
+import type { AppUser } from "./types";
+
+const admin: AppUser = { id: "admin", name: "Administrator", privileges: ["ADMIN"], roles: ["ORG_ADMIN"], organizationId: "org-1" };
+const caller: AppUser = { id: "caller", name: "Helistaja", privileges: ["ASSIGNED_OWNERS"], roles: ["CALLER"], organizationId: "org-1" };
+const viewer: AppUser = { id: "viewer", name: "Vaataja", privileges: [], roles: ["VIEWER"], organizationId: "org-1" };
+
+describe("route authorization", () => {
+  it("blocks forbidden routes before their workspace can mount", () => {
+    expect(hasAccess(viewer, requirementForPath("/integrations"))).toBe(false);
+    expect(hasAccess(caller, requirementForPath("/workdesk/evaluator"))).toBe(false);
+    expect(hasAccess(caller, requirementForPath("/owners/79601:001:9999"))).toBe(true);
+    expect(hasAccess(null, requirementForPath("/owners"))).toBe(false);
+  });
+
+  it("exposes navigation entries only to roles with the required privileges", () => {
+    const callerLinks = navigationItems.filter((item) => hasAccess(caller, item.requirement)).map((item) => item.href);
+    const adminLinks = navigationItems.filter((item) => hasAccess(admin, item.requirement)).map((item) => item.href);
+
+    expect(callerLinks).toContain("/owners");
+    expect(callerLinks).not.toContain("/workdesk/evaluator");
+    expect(callerLinks).not.toContain("/integrations");
+    expect(callerLinks).not.toContain("/admin");
+    expect(adminLinks).toContain("/integrations");
+    expect(adminLinks).toContain("/admin");
+  });
+
+  it("does not treat an unrelated route as privileged", () => {
+    expect(requirementForPath("/reminders")).toBeUndefined();
+    expect(hasAccess(viewer, requirementForPath("/reminders"))).toBe(true);
+  });
+});

--- a/forestiq-ui/client/src/lib/authorization.ts
+++ b/forestiq-ui/client/src/lib/authorization.ts
@@ -1,0 +1,62 @@
+import type { AppUser, OrganizationRole, Privilege } from "@/lib/types";
+
+export type AccessRequirement = {
+  anyPrivileges?: readonly Privilege[];
+  anyRoles?: readonly OrganizationRole[];
+};
+
+export type NavigationItem = {
+  label: string;
+  href: string;
+  requirement?: AccessRequirement;
+};
+
+const withPrivilege = (...anyPrivileges: Privilege[]): AccessRequirement => ({ anyPrivileges });
+
+export const routeAccess: Record<string, AccessRequirement | undefined> = {
+  "/owners": withPrivilege("ADMIN", "OWNER_PROFILE", "ASSIGNED_OWNERS"),
+  "/owners/import": withPrivilege("ADMIN", "OWNER_PROFILE", "ASSIGNED_OWNERS"),
+  "/map": withPrivilege("ADMIN", "OWNER_PROFILE", "ASSIGNED_OWNERS", "EVALUATION"),
+  "/deals": withPrivilege("ADMIN", "OWNER_PROFILE", "EVALUATION"),
+  "/inheritance": withPrivilege("ADMIN", "OWNER_PROFILE", "ASSIGNED_OWNERS"),
+  "/sales": withPrivilege("ADMIN", "OWNER_PROFILE", "ASSIGNED_OWNERS"),
+  "/integrations": withPrivilege("ADMIN"),
+  "/workdesk/caller": withPrivilege("ADMIN", "ASSIGNED_OWNERS"),
+  "/workdesk/evaluator": withPrivilege("ADMIN", "EVALUATION"),
+  "/workdesk/admin": withPrivilege("ADMIN"),
+  "/admin": withPrivilege("ADMIN"),
+  "/contracts": withPrivilege("ADMIN", "OWNER_PROFILE"),
+  "/phones": withPrivilege("ADMIN", "PHONES"),
+};
+
+export const navigationItems: readonly NavigationItem[] = [
+  { label: "Töölaud", href: "/home" },
+  { label: "Omanikud", href: "/owners", requirement: routeAccess["/owners"] },
+  { label: "Müügijärjekord", href: "/sales", requirement: routeAccess["/sales"] },
+  { label: "Tehingud", href: "/deals", requirement: routeAccess["/deals"] },
+  { label: "Pärimine", href: "/inheritance", requirement: routeAccess["/inheritance"] },
+  { label: "Kaart", href: "/map", requirement: routeAccess["/map"] },
+  { label: "Hindamine", href: "/workdesk/evaluator", requirement: routeAccess["/workdesk/evaluator"] },
+  { label: "Meeldetuletused", href: "/reminders" },
+  { label: "Sõnumid", href: "/messages" },
+  { label: "Lepingud", href: "/contracts", requirement: routeAccess["/contracts"] },
+  { label: "Kontaktid", href: "/phones", requirement: routeAccess["/phones"] },
+  { label: "Import", href: "/owners/import", requirement: routeAccess["/owners/import"] },
+  { label: "Integratsioonid", href: "/integrations", requirement: routeAccess["/integrations"] },
+  { label: "Haldus", href: "/admin", requirement: routeAccess["/admin"] },
+];
+
+export function hasAccess(user: AppUser | null, requirement?: AccessRequirement): boolean {
+  if (!user) return false;
+  if (!requirement) return true;
+  const privilegeAllowed = !requirement.anyPrivileges?.length || requirement.anyPrivileges.some((code) => user.privileges.includes(code));
+  const roleAllowed = !requirement.anyRoles?.length || requirement.anyRoles.some((role) => user.roles.includes(role));
+  return privilegeAllowed && roleAllowed;
+}
+
+export function requirementForPath(pathname: string): AccessRequirement | undefined {
+  const matchedPath = Object.keys(routeAccess)
+    .filter((path) => pathname === path || pathname.startsWith(`${path}/`))
+    .sort((left, right) => right.length - left.length)[0];
+  return matchedPath ? routeAccess[matchedPath] : undefined;
+}

--- a/forestiq-ui/client/src/pages/AccessState.tsx
+++ b/forestiq-ui/client/src/pages/AccessState.tsx
@@ -1,0 +1,23 @@
+import { Link } from "wouter";
+
+export function AuthenticationRequired() {
+  return (
+    <main className="access-state" aria-labelledby="authentication-required-title">
+      <p className="eyebrow">FORESTIQ / SISSELUGIMINE</p>
+      <h1 id="authentication-required-title">Sisselogimine on vajalik</h1>
+      <p>See tööruum vajab kehtivat ForestIQ seanssi. Sisene jätkamiseks oma kontoga.</p>
+      <Link href="/" className="access-state-action">Ava sisselogimine</Link>
+    </main>
+  );
+}
+
+export function AccessDenied() {
+  return (
+    <main className="access-state" aria-labelledby="access-denied-title">
+      <p className="eyebrow">FORESTIQ / ÕIGUSED</p>
+      <h1 id="access-denied-title">403 — puudub ligipääsuõigus</h1>
+      <p>Sinu aktiivsel rollil ei ole sellele tööruumile õigust. Keelatud lehe andmeid ei ole laaditud.</p>
+      <Link href="/home" className="access-state-action">Tagasi töölauale</Link>
+    </main>
+  );
+}


### PR DESCRIPTION
## Kokkuvõte

Rakendab issue #47: route-level privilege-valve, õiguspõhine külgriba navigatsioon ning eristatavad autentimis-, 403- ja 404 vaated.

## Muudatused

- Lisab keskse TypeScripti õiguste maatriksi, mis seob tööruumid serveri kinnitatud `privileges` claim’idega.
- Route-valve ei monteeri keelatud tööruumi komponenti, seega selle andmepäringud ei käivitu.
- Keelatud autentitud kasutajale kuvatakse 403 vaade; seansita kasutajale eraldi sisselogimisnõude vaade; tundmatu URL kuvab päris 404 vaate.
- Külgriba kuvab ainult aktiivse kasutaja õigustega lubatud menüüpunktid.
- Lisab Vitesti regressioonitestid dünaamilise omaniku-route’i, helistaja/hindaja/admini õiguste ning navigeerimisfiltri jaoks.

## Kontroll

Läbisid Vitest, TypeScripti `check`, ESLint ja tootmisbuild.

Closes #47