### PR TITLE
[QA-03] Lisa Vitest komponenditestid ja Playwrighti kriitilised E2E vood

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -125,6 +125,14 @@ jobs:
         working-directory: forestiq-ui
         run: pnpm test
 
+      - name: Install Playwright Chromium
+        working-directory: forestiq-ui
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run deterministic critical E2E workflows
+        working-directory: forestiq-ui
+        run: pnpm test:e2e
+
       - name: Build
         working-directory: forestiq-ui
         run: pnpm build

--- a/docs/QA_E2E_MANUAL_CHECKLIST.md
+++ b/docs/QA_E2E_MANUAL_CHECKLIST.md
@@ -1,0 +1,17 @@
+# Kriitiliste töövoogude käsitsi kontroll
+
+## MapLibre’i kaart → katastri detail
+
+Playwright katab kaarditööruumi laadimise ja kasutajajuhise. Katastrikihi klikki ning detailakna avamist kontrollitakse praegu käsitsi, sest headless Chromiumi MapLibre’i canvas ei renderda interaktiivseid GeoJSON-kihte järjepidevalt.
+
+| Samm | Kontroll | Oodatud tulemus |
+|---|---|---|
+| 1 | Sisene ForestIQ arenduskontoga ja ava **Kaart**. | Kuvatakse pealkiri **Metsa- ja katastrivaade** ning kaardil on kihid nähtavad. |
+| 2 | Suumi vähemalt tasemele 8 ning oota nähtava ala andmete laadimist. | Katastriüksuste kihi loendur suureneb, kui nähtaval alal on andmeid. |
+| 3 | Klõpsa nähtaval katastriüksusel. | Avaneb dialoog **Katastriüksuse detailvaade**. |
+| 4 | Kontrolli detailakna kokkuvõtet ja sektsioone. | Kuvatakse katastri, omanike/kliendisuhte, tegevuste, teatiste ja Metsaregistri andmed või nende selged tühjad olekud. |
+| 5 | Sulge detailaken. | Kaarditööruum jääb avatuks ning valitud objekti olek ei põhjusta JavaScripti vigu ega uut sisselogimist. |
+
+## Automaatne katvus
+
+Playwrighti `pnpm test:e2e` kontrollib deterministlike API-fixture’idega sisselogimist, hindamine → pakkumine → lepingu draft töövoogu, pärimisjuhtumi töötlust, omanike faili inspect → preview → commit importi, rollikeeldu ning kaarditööruumi esmast laadimist. Vitest katab lisaks õiguste maatriksi ja autentimis-/403-vaadete komponendid.

--- a/forestiq-ui/client/src/pages/AccessState.test.tsx
+++ b/forestiq-ui/client/src/pages/AccessState.test.tsx
@@ -1,0 +1,30 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { AccessDenied, AuthenticationRequired } from "./AccessState";
+
+describe("access state components", () => {
+  beforeAll(() => {
+    vi.stubGlobal("location", new URL("http://localhost/"));
+    vi.stubGlobal("history", { pushState: vi.fn(), replaceState: vi.fn() });
+  });
+
+  afterAll(() => {
+    vi.unstubAllGlobals();
+  });
+  it("renders a distinct authentication-required state", () => {
+    const html = renderToStaticMarkup(<AuthenticationRequired />);
+
+    expect(html).toContain("Sisselogimine on vajalik");
+    expect(html).toContain("Ava sisselogimine");
+    expect(html).not.toContain("403");
+  });
+
+  it("renders a distinct forbidden state and confirms protected data was not loaded", () => {
+    const html = renderToStaticMarkup(<AccessDenied />);
+
+    expect(html).toContain("403 — puudub ligipääsuõigus");
+    expect(html).toContain("Keelatud lehe andmeid ei ole laaditud.");
+    expect(html).toContain("Tagasi töölauale");
+  });
+});

--- a/forestiq-ui/e2e/critical-workflows.spec.ts
+++ b/forestiq-ui/e2e/critical-workflows.spec.ts
@@ -1,0 +1,110 @@
+import { expect, test } from "@playwright/test";
+
+import { authenticateSeededUser, installSeededApi } from "./seed";
+
+const ownerPath = "/owners/79601:001:9999";
+
+test.beforeEach(async ({ page }) => {
+  await installSeededApi(page);
+});
+
+test("login opens the deterministic development workspace", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await page.locator("input").nth(0).fill("qa-admin");
+  await page.locator("input").nth(1).fill("deterministic-password");
+  await page.locator("input").nth(2).fill("000000");
+  await page.getByRole("button", { name: "Ava arendustöölaud" }).click();
+
+  await expect(page).toHaveURL(/\/home$/);
+  await expect(page.getByText("Töölaud").first()).toBeVisible();
+});
+
+test("owner workflow completes evaluation, offer and contract draft", async ({
+  page,
+}) => {
+  await authenticateSeededUser(page);
+  await page.goto(ownerPath);
+  await expect(
+    page.getByRole("heading", { name: "Metsaomanik Mari", level: 2 }),
+  ).toBeVisible();
+
+  await page.getByLabel("Hindamise pakkumishind").fill("125000");
+  await page.getByRole("button", { name: "Kinnita hindamine" }).click();
+  await page.getByLabel("Pakkumise summa").fill("125000");
+  await page.getByRole("button", { name: "Saada pakkumine" }).click();
+  await page.getByRole("button", { name: "Koosta lepingu draft" }).click();
+
+  await expect(
+    page.getByText("Lepingu contract-0001 draft on loodud."),
+  ).toBeVisible();
+});
+
+test("owner workflow creates and starts an inheritance case", async ({
+  page,
+}) => {
+  await authenticateSeededUser(page);
+  await page.goto(ownerPath);
+  await expect(
+    page.getByRole("button", { name: "Kontrolli teadet" }),
+  ).toBeVisible();
+
+  await page.getByRole("button", { name: "Kontrolli teadet" }).click();
+  await page.getByRole("button", { name: "Loo juhtum" }).click();
+  await page.getByRole("button", { name: "Võta töösse" }).click();
+
+  await expect(page.getByText("IN PROGRESS").first()).toBeVisible();
+});
+
+test("owner import inspects, previews and commits one seeded CSV row", async ({
+  page,
+}) => {
+  await authenticateSeededUser(page);
+  await page.goto("/owners/import");
+  await page
+    .locator('input[type="file"]')
+    .setInputFiles({
+      name: "owners.csv",
+      mimeType: "text/csv",
+      buffer: Buffer.from("id,name\nowner-2,Seed owner\n"),
+    });
+  await page.getByRole("button", { name: "Kontrolli faili" }).click();
+
+  await expect(page.getByText("1 valmis · 0 tagasi lükatud")).toBeVisible();
+  await page.getByRole("button", { name: "Impordi 1 rida" }).click();
+  await expect(page.getByText("EELVAADE")).not.toBeVisible();
+});
+
+test("viewer receives a visible 403 and cannot trigger integration data requests", async ({
+  page,
+}) => {
+  const requestedUrls: string[] = [];
+  page.on("request", (request) =>
+    requestedUrls.push(new URL(request.url()).pathname),
+  );
+  await authenticateSeededUser(page, "viewer");
+  await page.goto("/integrations");
+
+  await expect(
+    page.getByRole("heading", { name: "403 — puudub ligipääsuõigus" }),
+  ).toBeVisible();
+  expect(requestedUrls).not.toContain("/api/services/admin/integrations");
+});
+
+test("map workspace renders its interactive map and cadastre guidance", async ({
+  page,
+}) => {
+  await authenticateSeededUser(page);
+  await page.goto("/map");
+
+  await expect(
+    page.getByRole("heading", { name: "Metsa- ja katastrivaade" }),
+  ).toBeVisible();
+  await expect(
+    page.getByLabel("Interaktiivne ForestIQ GeoDjango kaart"),
+  ).toBeVisible();
+  await expect(
+    page.getByText("klõpsa katastriüksusel tervikvaate avamiseks."),
+  ).toBeVisible();
+});

--- a/forestiq-ui/e2e/seed.ts
+++ b/forestiq-ui/e2e/seed.ts
@@ -1,0 +1,274 @@
+import type { Page, Route } from "@playwright/test";
+
+type SeedRole = "admin" | "viewer";
+
+const owner = {
+  id: "79601:001:9999",
+  name: "Metsaomanik Mari",
+  version: 1,
+  status: "IN_PROGRESS",
+  phone: "+372 5550 0000",
+  email: "mari@example.test",
+  address: "Metsatee 1",
+  cadastres: [
+    { id: "79601:001:9999", name: "Kuusiku", area: 12.4, marked: true },
+  ],
+};
+
+const adminClaims = {
+  userId: "qa-admin",
+  userName: "QA Admin",
+  privileges: [
+    "ADMIN",
+    "OWNER_PROFILE",
+    "ASSIGNED_OWNERS",
+    "EVALUATION",
+    "PHONES",
+  ],
+  roles: ["ORG_ADMIN"],
+  organizationId: "qa-org",
+  exp: 4_102_444_800,
+};
+const viewerClaims = {
+  userId: "qa-viewer",
+  userName: "QA Viewer",
+  privileges: [],
+  roles: ["VIEWER"],
+  organizationId: "qa-org",
+  exp: 4_102_444_800,
+};
+
+function token(claims: object): string {
+  const encode = (value: object) =>
+    Buffer.from(JSON.stringify(value)).toString("base64url");
+  return `${encode({ alg: "none", typ: "JWT" })}.${encode(claims)}.deterministic-signature`;
+}
+
+export const seededTokens = {
+  admin: token(adminClaims),
+  viewer: token(viewerClaims),
+  preAuth: token({ userId: "qa-admin", purpose: "pre-auth" }),
+};
+
+function json(route: Route, body: unknown, status = 200) {
+  return route.fulfill({
+    status,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  });
+}
+
+export async function installSeededApi(page: Page) {
+  const deals = [
+    {
+      id: "deal-0001",
+      version: 1,
+      owner,
+      saleSubject: "FOREST",
+      stage: "EVALUATION",
+      parcels: owner.cadastres,
+      offers: [],
+    },
+  ];
+  const inheritanceCases = [
+    {
+      id: "case-0001",
+      version: 1,
+      owner,
+      sourceNoticeNumber: "P-2026-1",
+      status: "NEW",
+      heirs: [],
+    },
+  ];
+
+  await page.route("**/api/**", async (route) => {
+    const request = route.request();
+    const { pathname } = new URL(request.url());
+    const method = request.method();
+    if (pathname === "/api/oidc/config")
+      return json(route, { enabled: false, localLoginEnabled: true });
+    if (pathname === "/api/password-login" && method === "POST")
+      return json(route, { token: seededTokens.preAuth });
+    if (pathname === "/api/services/totp" && method === "POST")
+      return json(route, {
+        actualToken: { token: seededTokens.admin },
+        refreshToken: { token: seededTokens.admin },
+      });
+    if (pathname === `/api/services/owners/${owner.id}` && method === "GET")
+      return json(route, owner);
+    if (pathname === "/api/services/owner-statuses")
+      return json(route, [
+        {
+          id: "IN_PROGRESS",
+          durationDays: 60,
+          colorHex: "c5edc8",
+          protectedStatus: true,
+        },
+      ]);
+    if (pathname === `/api/services/deals/owners/${owner.id}`)
+      return json(route, deals);
+    if (pathname === `/api/services/inheritance/owners/${owner.id}`)
+      return json(route, inheritanceCases);
+    if (pathname === `/api/services/ownership-transitions/owners/${owner.id}`)
+      return json(route, []);
+    if (
+      pathname.includes("/services/deals/") &&
+      pathname.endsWith("/evaluations") &&
+      method === "POST"
+    ) {
+      deals[0] = { ...deals[0], version: 2, stage: "NEGOTIATION" };
+      return json(route, deals[0]);
+    }
+    if (
+      pathname.includes("/services/deals/") &&
+      pathname.endsWith("/commercial/offers") &&
+      method === "POST"
+    )
+      return json(
+        route,
+        { offer: { id: "offer-0001" }, state: { version: 3 } },
+        201,
+      );
+    if (
+      pathname.includes("/services/deals/") &&
+      pathname.endsWith("/commercial/offers/send") &&
+      method === "POST"
+    ) {
+      deals[0] = {
+        ...deals[0],
+        version: 4,
+        stage: "WON",
+        offers: [
+          {
+            id: "offer-0001",
+            revision: 1,
+            kind: "OFFER",
+            status: "SENT",
+            amount: 125000,
+          },
+        ],
+      };
+      return json(route, deals[0]);
+    }
+    if (
+      pathname === "/api/services/contracts/generate-from-deal" &&
+      method === "POST"
+    )
+      return json(route, { contractId: "contract-0001" }, 201);
+    if (pathname.includes("/official-notices/check") && method === "POST")
+      return json(route, { notices: [] });
+    if (
+      pathname === `/api/services/inheritance/owners/${owner.id}` &&
+      method === "POST"
+    )
+      return json(route, inheritanceCases[0], 201);
+    if (
+      pathname.includes("/inheritance/cases/") &&
+      pathname.endsWith("/status") &&
+      method === "PATCH"
+    ) {
+      inheritanceCases[0] = { ...inheritanceCases[0], status: "IN_PROGRESS" };
+      return json(route, inheritanceCases[0]);
+    }
+    if (
+      pathname === "/api/services/owners/imports/inspect" &&
+      method === "POST"
+    )
+      return json(route, { suggestedMapping: { id: "id", name: "name" } });
+    if (
+      pathname === "/api/services/owners/imports/preview" &&
+      method === "POST"
+    )
+      return json(route, {
+        sha256: "deterministic-owner-import",
+        readyCount: 1,
+        rejectedCount: 0,
+        rows: [
+          {
+            rowNumber: 2,
+            id: "owner-2",
+            name: "Seed owner",
+            status: "READY",
+            reason: "",
+          },
+        ],
+      });
+    if (pathname === "/api/services/owners/imports/commit" && method === "POST")
+      return json(route, { created: 1, updated: 0 }, 201);
+    if (pathname === "/api/services/map/cadastres")
+      return json(route, {
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            id: "qa-cadastre",
+            properties: {
+              id: owner.cadastres[0].id,
+              cadastreId: owner.cadastres[0].id,
+              name: owner.cadastres[0].name,
+            },
+            geometry: {
+              type: "Polygon",
+              coordinates: [
+                [
+                  [25.58, 58.68],
+                  [25.62, 58.68],
+                  [25.62, 58.72],
+                  [25.58, 58.72],
+                  [25.58, 58.68],
+                ],
+              ],
+            },
+          },
+        ],
+      });
+    if (
+      pathname === `/api/services/cadastres/${owner.cadastres[0].id}/workspace`
+    )
+      return json(route, {
+        cadastre: {
+          id: owner.cadastres[0].id,
+          name: owner.cadastres[0].name,
+          area: 12.4,
+          county: "Jõgeva",
+          address: "Metsatee 1",
+        },
+        owners: [
+          {
+            id: owner.id,
+            name: owner.name,
+            phone: owner.phone,
+            email: owner.email,
+            customerRelationship: {
+              isCustomer: true,
+              ownerStatus: "IN_PROGRESS",
+              activeDealCount: 1,
+              wonDealCount: 0,
+            },
+          },
+        ],
+        activities: [],
+        notifications: [],
+        registryFeatures: [],
+        customerSummary: { customerOwnerCount: 1 },
+      });
+    if (pathname.includes("/services/map/"))
+      return json(route, { type: "FeatureCollection", features: [] });
+    if (pathname === "/api/services/status")
+      return json(route, { status: "OK", service: "forestiq-django" });
+    return json(route, []);
+  });
+}
+
+export async function authenticateSeededUser(
+  page: Page,
+  role: SeedRole = "admin",
+) {
+  await page.addInitScript(
+    ({ selectedRole, accessToken }) => {
+      localStorage.clear();
+      localStorage.setItem("forestiq_access_token", accessToken[selectedRole]);
+    },
+    { selectedRole: role, accessToken: seededTokens },
+  );
+}

--- a/forestiq-ui/package.json
+++ b/forestiq-ui/package.json
@@ -11,6 +11,7 @@
     "check": "tsc --noEmit",
     "lint": "eslint client server shared --max-warnings=0",
     "test": "vitest run",
+    "test:e2e": "playwright test",
     "format": "prettier --write ."
   },
   "dependencies": {
@@ -69,6 +70,7 @@
   },
   "devDependencies": {
     "@builder.io/vite-plugin-jsx-loc": "^0.1.1",
+    "@playwright/test": "1.54.2",
     "@tailwindcss/typography": "^0.5.15",
     "@tailwindcss/vite": "^4.1.3",
     "@types/express": "4.17.21",

--- a/forestiq-ui/playwright.config.ts
+++ b/forestiq-ui/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: false,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI
+    ? [
+        ["github"],
+        ["html", { outputFolder: "playwright-report", open: "never" }],
+      ]
+    : "list",
+  use: {
+    baseURL: "http://127.0.0.1:4173",
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  webServer: {
+    command: "pnpm exec vite --host 127.0.0.1 --port 4173",
+    url: "http://127.0.0.1:4173",
+    reuseExistingServer: !process.env.CI,
+    timeout: 30_000,
+  },
+});

--- a/forestiq-ui/pnpm-lock.yaml
+++ b/forestiq-ui/pnpm-lock.yaml
@@ -171,6 +171,9 @@ importers:
       '@builder.io/vite-plugin-jsx-loc':
         specifier: ^0.1.1
         version: 0.1.1(vite@7.1.9(@types/node@24.7.0)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.6))
+      '@playwright/test':
+        specifier: 1.54.2
+        version: 1.54.2
       '@tailwindcss/typography':
         specifier: ^0.5.15
         version: 0.5.19(tailwindcss@4.1.14)
@@ -816,6 +819,11 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@playwright/test@1.54.2':
+    resolution: {integrity: sha512-A+znathYxPf+72riFd1r1ovOLqsIIB0jKIoPjyK2kqEIe30/6jF6BC7QNluHuwUmsD2tv1XZVugN8GqfTMOxsA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -2648,6 +2656,11 @@ packages:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3373,6 +3386,16 @@ packages:
 
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
+
+  playwright-core@1.54.2:
+    resolution: {integrity: sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.54.2:
+    resolution: {integrity: sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   pnpm@10.18.1:
     resolution: {integrity: sha512-d6iEoWXLui2NHBnjtIgO7m0vyr0Nh5Eh4oIZa4AEI1HV6zygk1+lmdodxRJlzGiBatK93Sot5eqf35KtvsfNNA==}
@@ -4573,6 +4596,10 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
+
+  '@playwright/test@1.54.2':
+    dependencies:
+      playwright: 1.54.2
 
   '@radix-ui/number@1.1.1': {}
 
@@ -6567,6 +6594,9 @@ snapshots:
 
   fresh@0.5.2: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -7547,6 +7577,14 @@ snapshots:
       confbox: 0.2.2
       exsolve: 1.0.7
       pathe: 2.0.3
+
+  playwright-core@1.54.2: {}
+
+  playwright@1.54.2:
+    dependencies:
+      playwright-core: 1.54.2
+    optionalDependencies:
+      fsevents: 2.3.2
 
   pnpm@10.18.1: {}
 


### PR DESCRIPTION
## Kokkuvõte

Rakendab issue #54: deterministlikud Vitesti komponenditestid ning Playwrighti kriitiliste kasutajateekondade E2E kate.

## Muudatused

- Lisab Playwrighti Chromiumi konfiguratsiooni ja `pnpm test:e2e` käsu.
- Lisab API-fixture’idega korratavad E2E vood: sisselogimine, hindamine → pakkumine → lepingu draft, pärimisjuhtumi töötlus, omanike import ning rollikeeld.
- Lisab kaarditööruumi smoke-testi. MapLibre’i interaktiivne kaart → detailklikk jääb kasutaja soovil käsitsi kontrollitavaks; juhis on failis `docs/QA_E2E_MANUAL_CHECKLIST.md`.
- Lisab Vitesti komponenditestid autentimisnõude ning 403 õiguste puudumise vaadetele.
- Laiendab Quality Gate’i frontendi tööd Playwright Chromiumi paigalduse ja E2E käivitusega.

## Kohalik kontroll

Läbisid Vitest (6), Playwright (6), TypeScripti kontroll, ESLint ja tootmisbuild.

Closes #54