### PR TITLE
[UX-01] Lisa integratsioonide health-dashboard ja recovery detailid

### DIFF
--- a/forestiq-ui/client/src/App.tsx
+++ b/forestiq-ui/client/src/App.tsx
@@ -3,6 +3,7 @@ import { Redirect, Route, Switch } from "wouter";
 import { lazy, Suspense } from "react";
 
 import { Toaster } from "@/components/ui/sonner";
+import { IntegrationsHealthDashboard } from "@/components/IntegrationsHealthDashboard";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import ErrorBoundary from "@/components/ErrorBoundary";
 import { AuthProvider, useAuth } from "@/contexts/AuthContext";
@@ -15,52 +16,197 @@ import Messages from "@/pages/Messages";
 import NotFound from "@/pages/NotFound";
 import OwnerDetail from "@/pages/OwnerDetail";
 import Owners from "@/pages/Owners";
-import { DealsWorkspace, InheritanceWorkspace, IntegrationsWorkspace, OwnerImportWorkspace, SalesWorkspace } from "@/pages/ParityWorkspaces";
+import {
+  DealsWorkspace,
+  InheritanceWorkspace,
+  OwnerImportWorkspace,
+  SalesWorkspace,
+} from "@/pages/ParityWorkspaces";
 import Reminders from "@/pages/Reminders";
 import { GenericWorkspace, OwnerWorkspace } from "@/pages/Workspaces";
 
 const MapWorkspace = lazy(() => import("@/pages/MapWorkspace"));
 
-type ProtectedProps = { children: React.ReactNode; requirement?: AccessRequirement };
+type ProtectedProps = {
+  children: React.ReactNode;
+  requirement?: AccessRequirement;
+};
 
 function Protected({ children, requirement }: ProtectedProps) {
   const { user, ready } = useAuth();
-  if (!ready) return <div className="app-loading">Laadin ForestIQ töölauda…</div>;
+  if (!ready)
+    return <div className="app-loading">Laadin ForestIQ töölauda…</div>;
   if (!user) return <AuthenticationRequired />;
   if (!hasAccess(user, requirement)) return <AccessDenied />;
   return <>{children}</>;
 }
 
-const requirePrivileges = (...anyPrivileges: NonNullable<AccessRequirement["anyPrivileges"]>): AccessRequirement => ({ anyPrivileges });
+const requirePrivileges = (
+  ...anyPrivileges: NonNullable<AccessRequirement["anyPrivileges"]>
+): AccessRequirement => ({ anyPrivileges });
 
 function Routes() {
   return (
     <Switch>
       <Route path="/" component={Login} />
-      <Route path="/home"><Protected><Dashboard /></Protected></Route>
-      <Route path="/owners"><Protected requirement={requirePrivileges("ADMIN", "OWNER_PROFILE", "ASSIGNED_OWNERS")}><Owners /></Protected></Route>
-      <Route path="/owners/import"><Protected requirement={requirePrivileges("ADMIN", "OWNER_PROFILE", "ASSIGNED_OWNERS")}><OwnerImportWorkspace /></Protected></Route>
-      <Route path="/owners/:id"><Protected requirement={requirePrivileges("ADMIN", "OWNER_PROFILE", "ASSIGNED_OWNERS")}><OwnerDetail /></Protected></Route>
-      <Route path="/map"><Protected requirement={requirePrivileges("ADMIN", "OWNER_PROFILE", "ASSIGNED_OWNERS", "EVALUATION")}><Suspense fallback={<div className="app-loading">Laadin kaarditöölauda…</div>}><MapWorkspace /></Suspense></Protected></Route>
-      <Route path="/deals"><Protected requirement={requirePrivileges("ADMIN", "OWNER_PROFILE", "EVALUATION")}><DealsWorkspace /></Protected></Route>
-      <Route path="/inheritance"><Protected requirement={requirePrivileges("ADMIN", "OWNER_PROFILE", "ASSIGNED_OWNERS")}><InheritanceWorkspace /></Protected></Route>
-      <Route path="/sales"><Protected requirement={requirePrivileges("ADMIN", "OWNER_PROFILE", "ASSIGNED_OWNERS")}><SalesWorkspace /></Protected></Route>
-      <Route path="/integrations"><Protected requirement={requirePrivileges("ADMIN")}><IntegrationsWorkspace /></Protected></Route>
-      <Route path="/workdesk/caller"><Protected requirement={requirePrivileges("ADMIN", "ASSIGNED_OWNERS")}><OwnerWorkspace kind="caller" /></Protected></Route>
-      <Route path="/workdesk/evaluator"><Protected requirement={requirePrivileges("ADMIN", "EVALUATION")}><OwnerWorkspace kind="evaluator" /></Protected></Route>
-      <Route path="/workdesk/admin"><Protected requirement={requirePrivileges("ADMIN")}><OwnerWorkspace kind="admin" /></Protected></Route>
-      <Route path="/reminders"><Protected><Reminders /></Protected></Route>
-      <Route path="/messages"><Protected><Messages /></Protected></Route>
-      <Route path="/admin"><Protected requirement={requirePrivileges("ADMIN")}><Admin /></Protected></Route>
-      <Route path="/contracts"><Protected requirement={requirePrivileges("ADMIN", "OWNER_PROFILE")}><GenericWorkspace kind="contracts" /></Protected></Route>
-      <Route path="/phones"><Protected requirement={requirePrivileges("ADMIN", "PHONES")}><GenericWorkspace kind="phones" /></Protected></Route>
-      <Route path="/me"><Protected><GenericWorkspace kind="me" /></Protected></Route>
-      <Route path="/reminders-dashboard"><Protected><Reminders /></Protected></Route>
-      <Route><NotFound /></Route>
+      <Route path="/home">
+        <Protected>
+          <Dashboard />
+        </Protected>
+      </Route>
+      <Route path="/owners">
+        <Protected
+          requirement={requirePrivileges(
+            "ADMIN",
+            "OWNER_PROFILE",
+            "ASSIGNED_OWNERS",
+          )}
+        >
+          <Owners />
+        </Protected>
+      </Route>
+      <Route path="/owners/import">
+        <Protected
+          requirement={requirePrivileges(
+            "ADMIN",
+            "OWNER_PROFILE",
+            "ASSIGNED_OWNERS",
+          )}
+        >
+          <OwnerImportWorkspace />
+        </Protected>
+      </Route>
+      <Route path="/owners/:id">
+        <Protected
+          requirement={requirePrivileges(
+            "ADMIN",
+            "OWNER_PROFILE",
+            "ASSIGNED_OWNERS",
+          )}
+        >
+          <OwnerDetail />
+        </Protected>
+      </Route>
+      <Route path="/map">
+        <Protected
+          requirement={requirePrivileges(
+            "ADMIN",
+            "OWNER_PROFILE",
+            "ASSIGNED_OWNERS",
+            "EVALUATION",
+          )}
+        >
+          <Suspense
+            fallback={<div className="app-loading">Laadin kaarditöölauda…</div>}
+          >
+            <MapWorkspace />
+          </Suspense>
+        </Protected>
+      </Route>
+      <Route path="/deals">
+        <Protected
+          requirement={requirePrivileges(
+            "ADMIN",
+            "OWNER_PROFILE",
+            "EVALUATION",
+          )}
+        >
+          <DealsWorkspace />
+        </Protected>
+      </Route>
+      <Route path="/inheritance">
+        <Protected
+          requirement={requirePrivileges(
+            "ADMIN",
+            "OWNER_PROFILE",
+            "ASSIGNED_OWNERS",
+          )}
+        >
+          <InheritanceWorkspace />
+        </Protected>
+      </Route>
+      <Route path="/sales">
+        <Protected
+          requirement={requirePrivileges(
+            "ADMIN",
+            "OWNER_PROFILE",
+            "ASSIGNED_OWNERS",
+          )}
+        >
+          <SalesWorkspace />
+        </Protected>
+      </Route>
+      <Route path="/integrations">
+        <Protected requirement={requirePrivileges("ADMIN")}>
+          <IntegrationsHealthDashboard />
+        </Protected>
+      </Route>
+      <Route path="/workdesk/caller">
+        <Protected requirement={requirePrivileges("ADMIN", "ASSIGNED_OWNERS")}>
+          <OwnerWorkspace kind="caller" />
+        </Protected>
+      </Route>
+      <Route path="/workdesk/evaluator">
+        <Protected requirement={requirePrivileges("ADMIN", "EVALUATION")}>
+          <OwnerWorkspace kind="evaluator" />
+        </Protected>
+      </Route>
+      <Route path="/workdesk/admin">
+        <Protected requirement={requirePrivileges("ADMIN")}>
+          <OwnerWorkspace kind="admin" />
+        </Protected>
+      </Route>
+      <Route path="/reminders">
+        <Protected>
+          <Reminders />
+        </Protected>
+      </Route>
+      <Route path="/messages">
+        <Protected>
+          <Messages />
+        </Protected>
+      </Route>
+      <Route path="/admin">
+        <Protected requirement={requirePrivileges("ADMIN")}>
+          <Admin />
+        </Protected>
+      </Route>
+      <Route path="/contracts">
+        <Protected requirement={requirePrivileges("ADMIN", "OWNER_PROFILE")}>
+          <GenericWorkspace kind="contracts" />
+        </Protected>
+      </Route>
+      <Route path="/phones">
+        <Protected requirement={requirePrivileges("ADMIN", "PHONES")}>
+          <GenericWorkspace kind="phones" />
+        </Protected>
+      </Route>
+      <Route path="/me">
+        <Protected>
+          <GenericWorkspace kind="me" />
+        </Protected>
+      </Route>
+      <Route path="/reminders-dashboard">
+        <Protected>
+          <Reminders />
+        </Protected>
+      </Route>
+      <Route>
+        <NotFound />
+      </Route>
     </Switch>
   );
 }
 
 export default function App() {
-  return <ErrorBoundary><AuthProvider><TooltipProvider><Routes /><Toaster position="bottom-right" /></TooltipProvider></AuthProvider></ErrorBoundary>;
+  return (
+    <ErrorBoundary>
+      <AuthProvider>
+        <TooltipProvider>
+          <Routes />
+          <Toaster position="bottom-right" />
+        </TooltipProvider>
+      </AuthProvider>
+    </ErrorBoundary>
+  );
 }

--- a/forestiq-ui/client/src/components/IntegrationsHealthDashboard.tsx
+++ b/forestiq-ui/client/src/components/IntegrationsHealthDashboard.tsx
@@ -1,0 +1,392 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  Activity,
+  AlertTriangle,
+  CheckCircle2,
+  Clock3,
+  DatabaseZap,
+  RefreshCw,
+  RotateCcw,
+  X,
+} from "lucide-react";
+
+import { AppShell } from "@/components/AppShell";
+import { api } from "@/lib/api";
+import type {
+  IntegrationHealth,
+  IntegrationsHealthResponse,
+  SyncRun,
+} from "@/lib/types";
+
+const statusLabels: Record<string, string> = {
+  OK: "TÖÖKORRAS",
+  DEGRADED: "VAJAB TÄHELEPANU",
+  SUCCESS: "ÕNNESTUS",
+  PARTIAL: "OSALINE",
+  FAILED: "EBAÕNNESTUS",
+  SKIPPED: "VAHELE JÄETUD",
+  QUEUED: "JÄRJEKORRAS",
+  RUNNING: "TÖÖS",
+};
+
+function formatDate(value: string | null | undefined): string {
+  if (!value) return "andmed puuduvad";
+  return new Intl.DateTimeFormat("et-EE", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value));
+}
+
+function formatDuration(value: number | null): string {
+  if (value == null) return "—";
+  if (value < 60) return `${Math.round(value)} s`;
+  if (value < 3600) return `${Math.round(value / 60)} min`;
+  return `${(value / 3600).toFixed(1)} h`;
+}
+
+function HealthCard({
+  item,
+  run,
+  onOpenRun,
+  onRetry,
+  retrying,
+}: {
+  item: IntegrationHealth;
+  run?: SyncRun;
+  onOpenRun: (run: SyncRun) => void;
+  onRetry: (run: SyncRun) => void;
+  retrying: number | null;
+}) {
+  const degraded = item.health === "DEGRADED";
+  const canRetry =
+    !!run &&
+    (run.status === "PARTIAL" || run.status === "FAILED") &&
+    !!run.cadastre;
+  return (
+    <article className="work-card" aria-label={`${item.source} tervis`}>
+      <div className="flex min-w-0 items-start gap-3">
+        <span className={`status-pill ${degraded ? "warning" : ""}`}>
+          {statusLabels[item.health]}
+        </span>
+        <div className="min-w-0">
+          <h3>{item.source}</h3>
+          <p>
+            {degraded
+              ? "Värskus või viimaste jooksude seis vajab kontrolli."
+              : "Viimane auditijooks on värske ja õnnestunud."}
+          </p>
+        </div>
+      </div>
+      <dl className="mt-5 grid grid-cols-2 gap-x-4 gap-y-3 text-sm">
+        <div>
+          <dt className="text-muted-foreground">Viimane edu</dt>
+          <dd className="font-medium">{formatDate(item.lastSuccessAt)}</dd>
+        </div>
+        <div>
+          <dt className="text-muted-foreground">Viimane olek</dt>
+          <dd className="font-medium">
+            {statusLabels[item.lastStatus] || item.lastStatus}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-muted-foreground">Failure streak</dt>
+          <dd className="font-medium">{item.failureStreak}</dd>
+        </div>
+        <div>
+          <dt className="text-muted-foreground">Järjekord</dt>
+          <dd className="font-medium">{item.backlogSize}</dd>
+        </div>
+        <div className="col-span-2">
+          <dt className="text-muted-foreground">Cursor lag</dt>
+          <dd className="font-medium">{formatDuration(item.lagSeconds)}</dd>
+        </div>
+      </dl>
+      <div className="mt-5 flex flex-wrap gap-2">
+        {run && (
+          <button
+            className="secondary-action"
+            type="button"
+            onClick={() => onOpenRun(run)}
+          >
+            Ava jooksu detail
+          </button>
+        )}
+        {canRetry && (
+          <button
+            className="secondary-action"
+            type="button"
+            disabled={retrying === run.id}
+            onClick={() => onRetry(run)}
+          >
+            <RotateCcw size={16} />{" "}
+            {retrying === run.id ? "Käivitamine…" : "Käivita recovery"}
+          </button>
+        )}
+      </div>
+    </article>
+  );
+}
+
+function SyncRunDialog({
+  run,
+  onClose,
+}: {
+  run: SyncRun;
+  onClose: () => void;
+}) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/45 p-4"
+      role="presentation"
+      onMouseDown={onClose}
+    >
+      <section
+        className="panel max-h-[85vh] w-full max-w-2xl overflow-y-auto p-6 shadow-2xl"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="sync-run-detail-title"
+        onMouseDown={(event) => event.stopPropagation()}
+      >
+        <div className="flex items-start justify-between gap-6">
+          <div>
+            <p className="eyebrow">AUDIT / SÜNKRONISEERIMISJOOKS</p>
+            <h2 id="sync-run-detail-title">{run.source}</h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Jooks #{run.id} · {statusLabels[run.status] || run.status}
+            </p>
+          </div>
+          <button
+            className="secondary-action"
+            type="button"
+            aria-label="Sulge detail"
+            onClick={onClose}
+          >
+            <X size={16} />
+          </button>
+        </div>
+        <dl className="mt-6 grid grid-cols-1 gap-x-6 gap-y-4 text-sm sm:grid-cols-2">
+          <div>
+            <dt className="text-muted-foreground">Alustatud</dt>
+            <dd className="font-medium">{formatDate(run.startedAt)}</dd>
+          </div>
+          <div>
+            <dt className="text-muted-foreground">Lõpetatud</dt>
+            <dd className="font-medium">{formatDate(run.finishedAt)}</dd>
+          </div>
+          <div>
+            <dt className="text-muted-foreground">Töödeldud lehti / ridu</dt>
+            <dd className="font-medium">
+              {run.pagesProcessed} / {run.rowsProcessed}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-muted-foreground">Retry / backlog</dt>
+            <dd className="font-medium">
+              {run.retryCount} / {run.backlogSize}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-muted-foreground">Cursor</dt>
+            <dd className="break-all font-medium">{run.cursor || "—"}</dd>
+          </div>
+          <div>
+            <dt className="text-muted-foreground">Lag</dt>
+            <dd className="font-medium">{formatDuration(run.lagSeconds)}</dd>
+          </div>
+          {run.correlationId && (
+            <div className="sm:col-span-2">
+              <dt className="text-muted-foreground">Correlation ID</dt>
+              <dd className="break-all font-mono text-xs">
+                {run.correlationId}
+              </dd>
+            </div>
+          )}
+          {run.error && (
+            <div className="sm:col-span-2">
+              <dt className="text-muted-foreground">Viga</dt>
+              <dd className="mt-1 rounded-md bg-destructive/10 p-3 text-destructive">
+                {run.error}
+              </dd>
+            </div>
+          )}
+        </dl>
+      </section>
+    </div>
+  );
+}
+
+export function IntegrationsHealthDashboard() {
+  const [health, setHealth] = useState<IntegrationsHealthResponse | null>(null);
+  const [runs, setRuns] = useState<SyncRun[]>([]);
+  const [selectedRun, setSelectedRun] = useState<SyncRun | null>(null);
+  const [error, setError] = useState("");
+  const [refreshing, setRefreshing] = useState(false);
+  const [retrying, setRetrying] = useState<number | null>(null);
+
+  const refresh = async () => {
+    setRefreshing(true);
+    setError("");
+    try {
+      const [healthPayload, runPayload] = await Promise.all([
+        api.get<IntegrationsHealthResponse>(
+          "/services/admin/integrations/health",
+        ),
+        api.get<{ results: SyncRun[] }>("/services/admin/sync-runs"),
+      ]);
+      setHealth(healthPayload);
+      setRuns(runPayload.results);
+    } catch (caught) {
+      setError(
+        caught instanceof Error
+          ? caught.message
+          : "Integratsioonide terviseandmeid ei saanud laadida.",
+      );
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
+  useEffect(() => {
+    void refresh();
+  }, []);
+
+  const latestRunBySource = useMemo(
+    () =>
+      new Map(
+        health?.integrations.map((item) => [
+          item.source,
+          runs.find((run) => run.source.includes(item.source)),
+        ]),
+      ),
+    [health, runs],
+  );
+  const recoverStale = async () => {
+    setError("");
+    try {
+      await api.post("/services/registry/freshness/recover", { batchSize: 25 });
+      await refresh();
+    } catch (caught) {
+      setError(
+        caught instanceof Error
+          ? caught.message
+          : "Aegunud andmete taastamist ei saanud käivitada.",
+      );
+    }
+  };
+  const retryRun = async (run: SyncRun) => {
+    setRetrying(run.id);
+    setError("");
+    try {
+      const queued = await api.post<SyncRun>(
+        `/services/admin/sync-runs/${run.id}/retry`,
+        {},
+      );
+      setSelectedRun(queued);
+      await refresh();
+    } catch (caught) {
+      setError(
+        caught instanceof Error
+          ? caught.message
+          : "Sünkroonimisjooksu recovery’t ei saanud käivitada.",
+      );
+    } finally {
+      setRetrying(null);
+    }
+  };
+
+  const degradedCount = health?.degradedSources.length || 0;
+  const totalBacklog =
+    health?.integrations.reduce((total, item) => total + item.backlogSize, 0) ||
+    0;
+  return (
+    <AppShell
+      title="Integratsioonide ja värskuse haldus"
+      eyebrow="HALDUS / ANDMEVOOD"
+    >
+      <section className="workspace-intro">
+        <Activity size={24} />
+        <div>
+          <h2>Andmete värskus ja integratsioonide tervis</h2>
+          <p>
+            Seis tuletatakse auditeeritud sünkroonimisjooksudest;
+            välisandmeallikaid selles vaates ei probe’ita.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <button
+            className="secondary-action"
+            type="button"
+            disabled={refreshing}
+            onClick={() => void refresh()}
+          >
+            <RefreshCw size={16} /> Värskenda
+          </button>
+          <button
+            className="secondary-action"
+            type="button"
+            onClick={() => void recoverStale()}
+          >
+            <DatabaseZap size={16} /> Taasta aegunud
+          </button>
+        </div>
+      </section>
+      {error && (
+        <div className="connection-warning" role="alert">
+          {error}
+        </div>
+      )}
+      <section
+        className="metrics-grid"
+        aria-label="Integratsioonide koondnäitajad"
+      >
+        <div className="metric-card">
+          <span>Andmeallikaid</span>
+          <strong>{health?.integrations.length ?? "—"}</strong>
+        </div>
+        <div className="metric-card">
+          <span>Vajab tähelepanu</span>
+          <strong>{degradedCount}</strong>
+        </div>
+        <div className="metric-card">
+          <span>Järjekorras või töös</span>
+          <strong>{totalBacklog}</strong>
+        </div>
+      </section>
+      {!health && !error && (
+        <div className="empty-state">
+          <Clock3 size={18} /> Laadin integratsioonide terviseandmeid…
+        </div>
+      )}
+      {health?.integrations.length ? (
+        <section className="work-card-grid">
+          {health.integrations.map((item) => (
+            <HealthCard
+              key={item.source}
+              item={item}
+              run={latestRunBySource.get(item.source)}
+              onOpenRun={setSelectedRun}
+              onRetry={(run) => void retryRun(run)}
+              retrying={retrying}
+            />
+          ))}
+        </section>
+      ) : (
+        health && (
+          <div className="empty-state">
+            <AlertTriangle size={18} /> Auditeeritud integratsioonijookse ei ole
+            veel saadaval.
+          </div>
+        )
+      )}
+      {health?.status === "OK" && health.integrations.length > 0 && (
+        <p className="mt-5 flex items-center gap-2 text-sm text-emerald-700">
+          <CheckCircle2 size={17} /> Kõik auditeeritud integratsioonid on
+          värsked.
+        </p>
+      )}
+      {selectedRun && (
+        <SyncRunDialog run={selectedRun} onClose={() => setSelectedRun(null)} />
+      )}
+    </AppShell>
+  );
+}

--- a/forestiq-ui/client/src/lib/types.ts
+++ b/forestiq-ui/client/src/lib/types.ts
@@ -1,16 +1,167 @@
 /** ForestIQ Landscape Desk design: quiet Nordic data tooling with crisp operational hierarchy. */
-export type Privilege = "ADMIN" | "OWNER_PROFILE" | "ASSIGNED_OWNERS" | "PHONES" | "EVALUATION";
-export type OrganizationRole = "ORG_OWNER" | "ORG_ADMIN" | "ORG_MEMBER" | "CRM_MANAGER" | "EVALUATOR" | "CALLER" | "VIEWER";
-export interface AppUser { id: string; name: string; privileges: Privilege[]; roles: OrganizationRole[]; organizationId: string; }
-export interface Owner { id: string; name: string; version: number; status?: string | null; statusSetAt?: number | null; assignee?: { id: string; name: string } | null; phone?: string | null; email?: string | null; address?: string | null; info?: string | null; type?: string | null; cadastres?: Cadastre[]; }
-export interface Cadastre { id: string; name?: string | null; marked?: boolean; area?: number | null; forestArea?: number | null; type?: string | null; county?: string | null; municipality?: string | null; address?: string | null; labels?: string[]; }
-export interface Reminder { id: string; text: string; dueTime: number; owner?: Owner | null; creator?: string; }
-export interface Message { id: string; message: string; createdAt: number; sender?: { id: string; name: string } | null; recipient?: { id: string; name: string } | null; }
-export interface OwnerStatus { id: string; colorHex: string; durationDays: number; protectedStatus: boolean; }
-export interface Deal { id: string; version: number; owner: Owner; saleSubject: "FOREST" | "LAND" | "BOTH"; stage: string; parcels: Cadastre[]; qualificationNotes?: string | null; evaluator?: AppUser | null; evaluationStatus?: string | null; priceExpectation?: number | null; offers: DealOffer[]; updatedAt?: number | null; }
-export interface DealOffer { id: string; revision: number; kind: string; status: string; amount: number; validUntil?: string | null; terms?: string | null; }
-export interface InheritanceCase { id: string; version: number; owner: Owner; sourceNoticeNumber?: string | null; status: string; assignedTo?: AppUser | null; certificationDeadline?: string | null; heirs: InheritanceHeir[]; events: InheritanceEvent[]; updatedAt?: number | null; }
-export interface InheritanceHeir { id: string; displayName: string; phone?: string | null; email?: string | null; contactStatus?: string | null; }
-export interface InheritanceEvent { id: string; type: string; description: string; createdAt: number; }
-export interface SalesTask { owner: Owner; markedParcelCount: number; openDealCount: number; nextReminder?: number | null; }
-export interface IntegrationJob { key: string; label: string; configured: boolean; lastRun?: { id: number; status: string; finishedAt?: number | null; error?: string | null } | null; }
+export type Privilege =
+  | "ADMIN"
+  | "OWNER_PROFILE"
+  | "ASSIGNED_OWNERS"
+  | "PHONES"
+  | "EVALUATION";
+export type OrganizationRole =
+  | "ORG_OWNER"
+  | "ORG_ADMIN"
+  | "ORG_MEMBER"
+  | "CRM_MANAGER"
+  | "EVALUATOR"
+  | "CALLER"
+  | "VIEWER";
+export interface AppUser {
+  id: string;
+  name: string;
+  privileges: Privilege[];
+  roles: OrganizationRole[];
+  organizationId: string;
+}
+export interface Owner {
+  id: string;
+  name: string;
+  version: number;
+  status?: string | null;
+  statusSetAt?: number | null;
+  assignee?: { id: string; name: string } | null;
+  phone?: string | null;
+  email?: string | null;
+  address?: string | null;
+  info?: string | null;
+  type?: string | null;
+  cadastres?: Cadastre[];
+}
+export interface Cadastre {
+  id: string;
+  name?: string | null;
+  marked?: boolean;
+  area?: number | null;
+  forestArea?: number | null;
+  type?: string | null;
+  county?: string | null;
+  municipality?: string | null;
+  address?: string | null;
+  labels?: string[];
+}
+export interface Reminder {
+  id: string;
+  text: string;
+  dueTime: number;
+  owner?: Owner | null;
+  creator?: string;
+}
+export interface Message {
+  id: string;
+  message: string;
+  createdAt: number;
+  sender?: { id: string; name: string } | null;
+  recipient?: { id: string; name: string } | null;
+}
+export interface OwnerStatus {
+  id: string;
+  colorHex: string;
+  durationDays: number;
+  protectedStatus: boolean;
+}
+export interface Deal {
+  id: string;
+  version: number;
+  owner: Owner;
+  saleSubject: "FOREST" | "LAND" | "BOTH";
+  stage: string;
+  parcels: Cadastre[];
+  qualificationNotes?: string | null;
+  evaluator?: AppUser | null;
+  evaluationStatus?: string | null;
+  priceExpectation?: number | null;
+  offers: DealOffer[];
+  updatedAt?: number | null;
+}
+export interface DealOffer {
+  id: string;
+  revision: number;
+  kind: string;
+  status: string;
+  amount: number;
+  validUntil?: string | null;
+  terms?: string | null;
+}
+export interface InheritanceCase {
+  id: string;
+  version: number;
+  owner: Owner;
+  sourceNoticeNumber?: string | null;
+  status: string;
+  assignedTo?: AppUser | null;
+  certificationDeadline?: string | null;
+  heirs: InheritanceHeir[];
+  events: InheritanceEvent[];
+  updatedAt?: number | null;
+}
+export interface InheritanceHeir {
+  id: string;
+  displayName: string;
+  phone?: string | null;
+  email?: string | null;
+  contactStatus?: string | null;
+}
+export interface InheritanceEvent {
+  id: string;
+  type: string;
+  description: string;
+  createdAt: number;
+}
+export interface SalesTask {
+  owner: Owner;
+  markedParcelCount: number;
+  openDealCount: number;
+  nextReminder?: number | null;
+}
+export interface IntegrationJob {
+  key: string;
+  label: string;
+  configured: boolean;
+  lastRun?: {
+    id: number;
+    status: string;
+    finishedAt?: number | null;
+    error?: string | null;
+  } | null;
+}
+export interface IntegrationHealth {
+  source: string;
+  health: "OK" | "DEGRADED";
+  lastStatus: string;
+  lastSuccessAt: string | null;
+  failureStreak: number;
+  backlogSize: number;
+  lagSeconds: number | null;
+}
+export interface IntegrationsHealthResponse {
+  status: "OK" | "DEGRADED";
+  check: "integrations";
+  integrations: IntegrationHealth[];
+  degradedSources: string[];
+}
+export interface SyncRun {
+  id: number;
+  cadastre: string | null;
+  taskId: string | null;
+  correlationId: string | null;
+  source: string;
+  status: string;
+  pagesProcessed: number;
+  rowsProcessed: number;
+  retryCount: number;
+  backlogSize: number;
+  cursor: string;
+  lagSeconds: number | null;
+  retryOf: number | null;
+  startedAt: string | null;
+  finishedAt: string | null;
+  result: Record<string, unknown>;
+  error: string | null;
+}

--- a/forestiq-ui/e2e/critical-workflows.spec.ts
+++ b/forestiq-ui/e2e/critical-workflows.spec.ts
@@ -62,13 +62,11 @@ test("owner import inspects, previews and commits one seeded CSV row", async ({
 }) => {
   await authenticateSeededUser(page);
   await page.goto("/owners/import");
-  await page
-    .locator('input[type="file"]')
-    .setInputFiles({
-      name: "owners.csv",
-      mimeType: "text/csv",
-      buffer: Buffer.from("id,name\nowner-2,Seed owner\n"),
-    });
+  await page.locator('input[type="file"]').setInputFiles({
+    name: "owners.csv",
+    mimeType: "text/csv",
+    buffer: Buffer.from("id,name\nowner-2,Seed owner\n"),
+  });
   await page.getByRole("button", { name: "Kontrolli faili" }).click();
 
   await expect(page.getByText("1 valmis · 0 tagasi lükatud")).toBeVisible();
@@ -104,5 +102,42 @@ test("map workspace renders its interactive map and cadastre guidance", async ({
   await expect(
     page.getByLabel("Interaktiivne ForestIQ GeoDjango kaart"),
   ).toBeVisible();
-  await expect(page.getByText("Suured katastri- ja registrikihid laetakse MVT-paanidena")).toBeVisible();
+  await expect(
+    page.getByText("Suured katastri- ja registrikihid laetakse MVT-paanidena"),
+  ).toBeVisible();
+});
+
+test("admin sees integration freshness, opens sync-run detail and triggers recovery", async ({
+  page,
+}) => {
+  const recoveryRequests: string[] = [];
+  page.on("request", (request) => {
+    const pathname = new URL(request.url()).pathname;
+    if (pathname === "/api/services/registry/freshness/recover")
+      recoveryRequests.push(pathname);
+  });
+  await authenticateSeededUser(page);
+  await page.goto("/integrations");
+
+  await expect(
+    page.getByRole("heading", {
+      name: "Andmete värskus ja integratsioonide tervis",
+    }),
+  ).toBeVisible();
+  await expect(page.getByLabel("cadastre tervis")).toContainText(
+    "VAJAB TÄHELEPANU",
+  );
+  await expect(page.getByLabel("parimus tervis")).toContainText("TÖÖKORRAS");
+
+  await page.getByRole("button", { name: "Ava jooksu detail" }).first().click();
+  await expect(
+    page.getByRole("dialog", { name: "cadastre_wfs" }),
+  ).toContainText("Jooks #321");
+  await expect(
+    page.getByText("Metsaregistri lähteallikas vastas ajutise tõrkega."),
+  ).toBeVisible();
+  await page.getByRole("button", { name: "Sulge detail" }).click();
+
+  await page.getByRole("button", { name: "Taasta aegunud" }).click();
+  await expect.poll(() => recoveryRequests.length).toBe(1);
 });

--- a/forestiq-ui/e2e/seed.ts
+++ b/forestiq-ui/e2e/seed.ts
@@ -80,11 +80,86 @@ export async function installSeededApi(page: Page) {
       heirs: [],
     },
   ];
+  const syncRuns = [
+    {
+      id: 321,
+      cadastre: owner.cadastres[0].id,
+      taskId: "qa-task-321",
+      correlationId: "qa-correlation-321",
+      source: "cadastre_wfs",
+      status: "PARTIAL",
+      pagesProcessed: 3,
+      rowsProcessed: 120,
+      retryCount: 0,
+      backlogSize: 2,
+      cursor: "startIndex=150",
+      lagSeconds: 7200,
+      retryOf: null,
+      startedAt: "2026-08-27T08:00:00Z",
+      finishedAt: "2026-08-27T08:01:00Z",
+      result: { failed_sources: { metsaregister_wfs: "Ajutine tõrge" } },
+      error: "Metsaregistri lähteallikas vastas ajutise tõrkega.",
+    },
+  ];
+  const integrationsHealth = {
+    status: "DEGRADED",
+    check: "integrations",
+    integrations: [
+      {
+        source: "cadastre",
+        health: "DEGRADED",
+        lastStatus: "PARTIAL",
+        lastSuccessAt: "2026-08-27T06:00:00Z",
+        failureStreak: 1,
+        backlogSize: 2,
+        lagSeconds: 7200,
+      },
+      {
+        source: "parimus",
+        health: "OK",
+        lastStatus: "SUCCESS",
+        lastSuccessAt: "2026-08-27T09:00:00Z",
+        failureStreak: 0,
+        backlogSize: 0,
+        lagSeconds: 180,
+      },
+    ],
+    degradedSources: ["cadastre"],
+  };
 
   await page.route("**/api/**", async (route) => {
     const request = route.request();
     const { pathname } = new URL(request.url());
     const method = request.method();
+    if (
+      pathname === "/api/services/admin/integrations/health" &&
+      method === "GET"
+    )
+      return json(route, integrationsHealth);
+    if (pathname === "/api/services/admin/sync-runs" && method === "GET")
+      return json(route, { results: syncRuns });
+    if (
+      pathname === "/api/services/registry/freshness/recover" &&
+      method === "POST"
+    )
+      return json(route, { queued: 1 }, 202);
+    if (
+      pathname === "/api/services/admin/sync-runs/321/retry" &&
+      method === "POST"
+    )
+      return json(
+        route,
+        {
+          ...syncRuns[0],
+          id: 322,
+          status: "QUEUED",
+          retryCount: 1,
+          retryOf: 321,
+          error: null,
+          finishedAt: null,
+        },
+        202,
+      );
     if (pathname === "/api/oidc/config")
       return json(route, { enabled: false, localLoginEnabled: true });
     if (pathname === "/api/password-login" && method === "POST")


### PR DESCRIPTION
## Kokkuvõte

Rakendab issue #43, kasutades olemasolevaid OPS-03 health- ning ING-04 auditi/retry lepinguid.

## Muudatused

- Lisab adminiõigusega `/integrations` vaatesse auditeeritud tervise- ja värskusdashboardi.
- Kuvab iga allika viimase edu, viimase oleku, failure streak’i, backlog’i ning cursor lag’i.
- Avab seotud sünkroonimisjooksu detaili: ajad, töödeldud lehed/read, retry, cursor, lag, correlation ID ja turvaline veateade.
- Võimaldab taaskäivitada aegunud andmete recovery voo ning päris API kaudu PARTIAL/FAILED katastrijooksu retry.
- Lisab deterministliku Playwrighti testi dashboardi, detailivaate ja recovery tegevuse jaoks.

## Kontroll

Lokaalselt läbisid `pnpm check`, `pnpm lint`, `pnpm test`, `pnpm test:coverage:critical`, kõik 7 Playwrighti E2E testi ja tootmisbuild.

Closes #43