### PR TITLE
feat(admin): add organization dashboard stats

### DIFF
--- a/api_contracts/openapi-v1.yaml
+++ b/api_contracts/openapi-v1.yaml
@@ -99,6 +99,15 @@ paths:
       responses:
         '200':
           description: No response body
+  /api/v1/services/admin/dashboard-stats:
+    get:
+      operationId: services_admin_dashboard_stats_retrieve
+      description: Return compact organization-scoped management counts for the dashboard.
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
   /api/v1/services/admin/integrations:
     get:
       operationId: services_admin_integrations_retrieve

--- a/django_backend/api/tests.py
+++ b/django_backend/api/tests.py
@@ -19,7 +19,7 @@ from api.auth import token_pair
 from api.urls import urlpatterns
 from accounts.models import Organization, OrganizationMembership, OrganizationRole, Privilege, PrivilegeCode, User
 from forestry.models import Cadastre, DataSyncRun, Owner, OwnerStatus
-from operations.models import CompanyProfile, Contract, ContractTemplate, Deal, DealOffer, InheritanceCase, Reminder
+from operations.models import CompanyProfile, Contract, ContractTemplate, Deal, DealOffer, DealStage, InheritanceCase, Reminder
 
 
 class RenderCorsTests(TestCase):

--- a/django_backend/api/tests.py
+++ b/django_backend/api/tests.py
@@ -2,10 +2,15 @@
 
 import base64
 import json
+import time
+from datetime import timedelta
 from unittest.mock import Mock, patch
 
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.db import connection
 from django.test import SimpleTestCase, TestCase, override_settings
+from django.test.utils import CaptureQueriesContext
+from django.utils import timezone
 from rest_framework.permissions import AllowAny
 from rest_framework.test import APIClient
 from rest_framework_simplejwt.tokens import RefreshToken
@@ -115,6 +120,50 @@ class AdminWorkflowTests(TestCase):
         self.assertEqual(response.status_code, 200)
         owner.refresh_from_db()
         self.assertEqual(owner.status, "ASSIGNED")
+
+
+class DashboardStatsTests(TestCase):
+    def setUp(self):
+        self.organization = Organization.objects.create(slug="dashboard-org", name="Dashboard organization")
+        self.other_organization = Organization.objects.create(slug="dashboard-other", name="Other dashboard organization")
+        self.admin = User.objects.create_user("dashboard-admin", "Dashboard administrator", "very-secure-admin-password", default_organization=self.organization)
+        Privilege.objects.create(user=self.admin, code=PrivilegeCode.ADMIN)
+        self.client = APIClient()
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {token_pair(self.admin)['actualToken']['token']}")
+        now = timezone.now()
+        self.new_owner = Owner.objects.create(id="11111:001:0001", name="New lead", status="NEW", organization=self.organization)
+        self.evaluation_owner = Owner.objects.create(id="11111:001:0002", name="Evaluation lead", status="WAITS_FOR_EVALUATION", organization=self.organization)
+        Owner.objects.create(id="11111:001:0003", name="Out of search", status="NEW", organization=self.organization, out_of_admin_search_from=now, out_of_admin_search_to=now + timedelta(days=1))
+        Owner.objects.create(id="22222:001:0001", name="Other organization lead", status="NEW", organization=self.other_organization)
+        Deal.objects.create(owner=self.new_owner, sale_subject="FOREST", stage=DealStage.NEGOTIATION, offer_valid_until=timezone.localdate() + timedelta(days=2))
+        Deal.objects.create(owner=self.evaluation_owner, sale_subject="LAND", stage=DealStage.EVALUATION, offer_valid_until=timezone.localdate() - timedelta(days=1))
+        Reminder.objects.create(owner=self.new_owner, creator=self.admin, text="Follow up", due_time=now + timedelta(days=2), organization=self.organization)
+        Reminder.objects.create(owner=self.evaluation_owner, creator=self.admin, text="Overdue", due_time=now - timedelta(days=1), organization=self.organization)
+        InheritanceCase.objects.create(owner=self.new_owner, status=InheritanceCase.Status.IN_PROGRESS, certification_deadline=timezone.localdate() + timedelta(days=1), organization=self.organization)
+
+    def test_dashboard_stats_is_organization_scoped_and_compact(self):
+        with CaptureQueriesContext(connection) as queries:
+            response = self.client.get("/api/services/admin/dashboard-stats")
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(response.data["activeOwners"], 2)
+        self.assertEqual(response.data["newLeads"], 1)
+        self.assertEqual(response.data["evaluationPending"], 1)
+        self.assertEqual(response.data["deadlines"]["overdue"], 2)
+        self.assertEqual(response.data["deadlines"]["nextSevenDays"], 3)
+        self.assertEqual(response.data["dealStages"][DealStage.NEGOTIATION], 1)
+        self.assertEqual(response.data["dealStages"][DealStage.EVALUATION], 1)
+        self.assertLessEqual(len(queries), 12, [query["sql"] for query in queries])
+
+    def test_dashboard_stats_fixed_corpus_p95_stays_within_budget(self):
+        samples = []
+        for _ in range(15):
+            started = time.perf_counter()
+            response = self.client.get("/api/services/admin/dashboard-stats")
+            samples.append((time.perf_counter() - started) * 1000)
+            self.assertEqual(response.status_code, 200, response.data)
+        p95_ms = sorted(samples)[-1]  # nearest-rank p95 for the fixed 15-request corpus
+        print(f"DashboardStats fixed corpus: samples={len(samples)}, p95_ms={p95_ms:.2f}, query_budget=12")
+        self.assertLessEqual(p95_ms, 500, f"DashboardStats p95 {p95_ms:.2f}ms exceeded the 500ms budget")
 
 
 class ContractConfigurationTests(TestCase):

--- a/django_backend/api/urls.py
+++ b/django_backend/api/urls.py
@@ -19,6 +19,7 @@ urlpatterns = [
     path("services/admin/users/<str:user_id>", views.admin_user_detail),
     path("services/admin/userstatistics/prep-data", views.user_statistics_prep),
     path("services/admin/userstatistics/owner-status-change", views.user_statistics),
+    path("services/admin/dashboard-stats", views.dashboard_stats),
     path("services/admin/sync-runs", views.sync_runs),
     path("services/admin/sync-runs/<int:run_id>/retry", views.retry_sync_run),
     path("services/admin/cadastres/<str:cadastre_id>/sync", views.cadastre_sync),

--- a/django_backend/api/views.py
+++ b/django_backend/api/views.py
@@ -36,7 +36,7 @@ from forestry.models import (
     OwnerStatus,
     OwnerStatusChange,
 )
-from operations.models import ApplicationMessage, Contract, ContractHistory, Deal, DealStage, DirectMessage, PersonDump, Reminder
+from operations.models import ApplicationMessage, Contract, ContractHistory, Deal, DealStage, DirectMessage, InheritanceCase, PersonDump, Reminder
 
 from .concurrency import delete_if_current, missing_version_response, requested_version, update_if_current, version_conflict_response
 from .organization import organization_user_or_404, organization_users, request_organization_id
@@ -1155,3 +1155,46 @@ def user_statistics(request):
         .order_by("user_id")
     )
     return Response([{"userId": frame["user_id"], "statisticsFrames": [{"since": None, "count": frame["count"]}]} for frame in frames])
+
+
+@api_view(["GET"])
+@permission_classes([IsAdmin])
+def dashboard_stats(request):
+    """Return compact organization-scoped management counts for the dashboard."""
+
+    organization_id = request_organization_id(request)
+    now = timezone.now()
+    today = timezone.localdate(now)
+    upcoming_at = now + timedelta(days=7)
+    upcoming_date = today + timedelta(days=7)
+    active_owner_scope = Q(out_of_admin_search_from__isnull=True) | Q(out_of_admin_search_to__lte=now)
+    owners = Owner.objects.filter(organization_id=organization_id).filter(active_owner_scope)
+    deals = Deal.objects.filter(organization_id=organization_id)
+    reminders = Reminder.objects.filter(organization_id=organization_id)
+    inheritance_cases = InheritanceCase.objects.filter(organization_id=organization_id).exclude(status__in=["COMPLETED", "CLOSED"])
+
+    deal_stage_counts = {stage: 0 for stage, _label in DealStage.choices}
+    deal_stage_counts.update({frame["stage"]: frame["count"] for frame in deals.values("stage").annotate(count=Count("id"))})
+    reminder_overdue = reminders.filter(due_time__lt=now).count()
+    reminder_upcoming = reminders.filter(due_time__gte=now, due_time__lte=upcoming_at).count()
+    inheritance_overdue = inheritance_cases.filter(certification_deadline__lt=today).count()
+    inheritance_upcoming = inheritance_cases.filter(certification_deadline__gte=today, certification_deadline__lte=upcoming_date).count()
+    offer_overdue = deals.exclude(stage__in=[DealStage.WON, DealStage.LOST, DealStage.CANCELLED]).filter(offer_valid_until__lt=today).count()
+    offer_upcoming = deals.exclude(stage__in=[DealStage.WON, DealStage.LOST, DealStage.CANCELLED]).filter(offer_valid_until__gte=today, offer_valid_until__lte=upcoming_date).count()
+
+    return Response(
+        {
+            "activeOwners": owners.count(),
+            "newLeads": owners.filter(Q(status="") | Q(status="NEW")).count(),
+            "evaluationPending": owners.filter(status="WAITS_FOR_EVALUATION").count(),
+            "deadlines": {
+                "overdue": reminder_overdue + inheritance_overdue + offer_overdue,
+                "nextSevenDays": reminder_upcoming + inheritance_upcoming + offer_upcoming,
+                "reminders": {"overdue": reminder_overdue, "nextSevenDays": reminder_upcoming},
+                "inheritance": {"overdue": inheritance_overdue, "nextSevenDays": inheritance_upcoming},
+                "offers": {"overdue": offer_overdue, "nextSevenDays": offer_upcoming},
+            },
+            "dealStages": deal_stage_counts,
+            "generatedAt": now,
+        }
+    )


### PR DESCRIPTION
Closes #35

## Summary
- adds a compact organization-scoped DashboardStats API
- reports active owners, new leads, evaluation queue, deadlines and deal stages
- adds a fixed-corpus query-count and p95 performance regression test
- updates the API v1 OpenAPI snapshot

## Validation
- `USE_SQLITE_FOR_TESTS=1 python3 manage.py check`
- `python3 -m py_compile api/views.py api/tests.py`
- full test suite and performance verification run against PostGIS in Quality Gate