### PR TITLE
feat(contracts): add template placeholder previews

### DIFF
--- a/api_contracts/openapi-v1.yaml
+++ b/api_contracts/openapi-v1.yaml
@@ -626,6 +626,28 @@ paths:
       responses:
         '204':
           description: No response body
+  /api/v1/services/contract-templates/{template_id}/preview:
+    post:
+      operationId: services_contract_templates_preview_create
+      parameters:
+      - in: path
+        name: template_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
+  /api/v1/services/contract-templates/placeholders:
+    get:
+      operationId: services_contract_templates_placeholders_retrieve
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
   /api/v1/services/contracts:
     get:
       operationId: services_contracts_retrieve

--- a/django_backend/api/contract_templates.py
+++ b/django_backend/api/contract_templates.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from html import escape
+import re
+
 from django.core.exceptions import ValidationError
 from django.core.validators import URLValidator, validate_email, validate_slug
 from django.db import IntegrityError, transaction
@@ -12,7 +15,7 @@ from rest_framework.decorators import api_view, permission_classes
 from rest_framework.response import Response
 
 from accounts.models import Organization
-from operations.models import CompanyProfile, ContractTemplate
+from operations.models import CompanyProfile, ContractTemplate, Deal
 
 from .concurrency import missing_version_response, requested_version, version_conflict_response
 from .organization import request_organization_id
@@ -20,6 +23,70 @@ from .permissions import IsAdmin
 
 
 MAX_TEMPLATE_HTML_BYTES = 512_000
+PLACEHOLDER_PATTERN = re.compile(r"{{\s*([a-zA-Z][a-zA-Z0-9_.]*)\s*}}")
+PLACEHOLDER_CATALOG = (
+    {"key": "company.legalName", "label": "Ettevõtte juriidiline nimi", "required": True},
+    {"key": "company.registryCode", "label": "Ettevõtte registrikood", "required": False},
+    {"key": "company.vatNumber", "label": "Ettevõtte käibemaksukohustuslase number", "required": False},
+    {"key": "company.address", "label": "Ettevõtte aadress", "required": False},
+    {"key": "company.email", "label": "Ettevõtte e-post", "required": False},
+    {"key": "company.phone", "label": "Ettevõtte telefon", "required": False},
+    {"key": "company.iban", "label": "Ettevõtte IBAN", "required": False},
+    {"key": "company.signatoryName", "label": "Allkirjastaja nimi", "required": False},
+    {"key": "deal.id", "label": "Tehingu ID", "required": True},
+    {"key": "deal.ownerName", "label": "Omaniku nimi", "required": True},
+    {"key": "deal.saleSubject", "label": "Müügiobjekt", "required": True},
+    {"key": "deal.stage", "label": "Tehingu etapp", "required": False},
+    {"key": "deal.priceExpectation", "label": "Omaniku hinnaootus", "required": False},
+    {"key": "deal.recommendedPurchasePrice", "label": "Soovituslik ostuhind", "required": False},
+    {"key": "deal.offerValidUntil", "label": "Pakkumise kehtivus", "required": False},
+)
+PLACEHOLDER_KEYS = {item["key"] for item in PLACEHOLDER_CATALOG}
+REQUIRED_PLACEHOLDER_KEYS = {item["key"] for item in PLACEHOLDER_CATALOG if item["required"]}
+
+
+def _template_placeholders(html: str) -> set[str]:
+    matches = list(PLACEHOLDER_PATTERN.finditer(html))
+    placeholders = {match.group(1) for match in matches}
+    if html.count("{{") != len(matches) or html.count("}}") != len(matches):
+        raise ValueError("html contains an unclosed or malformed placeholder.")
+    unknown = sorted(placeholders - PLACEHOLDER_KEYS)
+    if unknown:
+        raise ValueError(f"html contains unknown placeholders: {', '.join(unknown)}.")
+    missing = sorted(REQUIRED_PLACEHOLDER_KEYS - placeholders)
+    if missing:
+        raise ValueError(f"html is missing required placeholders: {', '.join(missing)}.")
+    return placeholders
+
+
+def _display(value) -> str:
+    return "" if value in {None, ""} else str(value)
+
+
+def _preview_values(template: ContractTemplate, deal: Deal) -> dict[str, str]:
+    company = template.company_profile
+    return {
+        "company.legalName": _display(company.legal_name if company else None),
+        "company.registryCode": _display(company.registry_code if company else None),
+        "company.vatNumber": _display(company.vat_number if company else None),
+        "company.address": _display(company.address if company else None),
+        "company.email": _display(company.email if company else None),
+        "company.phone": _display(company.phone if company else None),
+        "company.iban": _display(company.iban if company else None),
+        "company.signatoryName": _display(company.signatory_name if company else None),
+        "deal.id": str(deal.id),
+        "deal.ownerName": deal.owner.name,
+        "deal.saleSubject": deal.sale_subject,
+        "deal.stage": deal.stage,
+        "deal.priceExpectation": _display(deal.price_expectation),
+        "deal.recommendedPurchasePrice": _display(deal.recommended_purchase_price),
+        "deal.offerValidUntil": _display(deal.offer_valid_until),
+    }
+
+
+def _render_preview(template: ContractTemplate, deal: Deal) -> str:
+    values = _preview_values(template, deal)
+    return PLACEHOLDER_PATTERN.sub(lambda match: escape(values[match.group(1)]), template.html)
 
 
 def _detail(message: str, http_status: int = status.HTTP_400_BAD_REQUEST) -> Response:
@@ -118,6 +185,7 @@ def _template_values(data, organization: Organization, *, fallback: ContractTemp
         raise ValueError("html is required.")
     if len(html.encode("utf-8")) > MAX_TEMPLATE_HTML_BYTES:
         raise ValueError(f"html exceeds the {MAX_TEMPLATE_HTML_BYTES} byte safety limit.")
+    _template_placeholders(html)
     try:
         validate_slug(template_key)
     except ValidationError as exc:
@@ -213,6 +281,23 @@ def contract_templates(request):
         next_version = (templates.filter(template_key=values["template_key"]).aggregate(highest=Max("version"))["highest"] or 0) + 1
         template = ContractTemplate.objects.create(organization=organization, version=next_version, created_by=request.user, **values)
     return Response(_template_data(template), status=status.HTTP_201_CREATED)
+
+
+@api_view(["GET"])
+@permission_classes([IsAdmin])
+def contract_template_placeholders(request):
+    return Response({"placeholders": PLACEHOLDER_CATALOG})
+
+
+@api_view(["POST"])
+@permission_classes([IsAdmin])
+def contract_template_preview(request, template_id: str):
+    template = get_object_or_404(_template_queryset(request).filter(is_active=True), id=template_id)
+    deal_id = request.data.get("dealId")
+    if not deal_id:
+        return _detail("dealId is required.")
+    deal = get_object_or_404(Deal.objects.select_related("owner").filter(organization=_organization(request)), id=deal_id)
+    return Response({"templateId": str(template.id), "dealId": str(deal.id), "html": _render_preview(template, deal)})
 
 
 @api_view(["GET", "PATCH", "DELETE"])

--- a/django_backend/api/tests.py
+++ b/django_backend/api/tests.py
@@ -187,18 +187,53 @@ class ContractConfigurationTests(TestCase):
 
     def test_admin_can_revise_html_template_without_losing_prior_version(self):
         profile = CompanyProfile.objects.create(organization=self.organization, legal_name="ForestIQ OÜ")
-        created = self.client.post("/api/services/contract-templates", {"companyProfileId": str(profile.id), "templateKey": "forest-sale", "name": "Müügileping", "html": "<h1>Version 1</h1>"}, format="json")
+        created = self.client.post("/api/services/contract-templates", {"companyProfileId": str(profile.id), "templateKey": "forest-sale", "name": "Müügileping", "html": "<h1>Version 1 {{ company.legalName }} {{ deal.id }} {{ deal.ownerName }} {{ deal.saleSubject }}</h1>"}, format="json")
         self.assertEqual(created.status_code, 201, created.data)
-        successor = self.client.patch(f"/api/services/contract-templates/{created.data['id']}", {"version": 1, "html": "<h1>Version 2</h1>"}, format="json")
+        successor = self.client.patch(f"/api/services/contract-templates/{created.data['id']}", {"version": 1, "html": "<h1>Version 2 {{ company.legalName }} {{ deal.id }} {{ deal.ownerName }} {{ deal.saleSubject }}</h1>"}, format="json")
         self.assertEqual(successor.status_code, 201, successor.data)
         self.assertEqual(successor.data["version"], 2)
         original = ContractTemplate.objects.get(id=created.data["id"])
         self.assertFalse(original.is_active)
-        self.assertEqual(original.html, "<h1>Version 1</h1>")
+        self.assertEqual(original.html, "<h1>Version 1 {{ company.legalName }} {{ deal.id }} {{ deal.ownerName }} {{ deal.saleSubject }}</h1>")
         self.assertEqual(successor.data["supersedesId"], created.data["id"])
         active = self.client.get("/api/services/contract-templates?active=true")
         self.assertEqual(active.status_code, 200, active.data)
         self.assertEqual([item["id"] for item in active.data], [successor.data["id"]])
+
+
+    def test_placeholder_catalog_and_validation_prevent_invalid_activation(self):
+        catalog = self.client.get("/api/services/contract-templates/placeholders")
+        self.assertEqual(catalog.status_code, 200, catalog.data)
+        required = {item["key"] for item in catalog.data["placeholders"] if item["required"]}
+        self.assertEqual(required, {"company.legalName", "deal.id", "deal.ownerName", "deal.saleSubject"})
+        unknown = self.client.post("/api/services/contract-templates", {"templateKey": "unknown", "name": "Unknown", "html": "{{ company.legalName }} {{ deal.id }} {{ deal.ownerName }} {{ deal.saleSubject }} {{ deal.secret }}"}, format="json")
+        self.assertEqual(unknown.status_code, 400, unknown.data)
+        self.assertIn("unknown placeholders", unknown.data["detail"])
+        incomplete = self.client.post("/api/services/contract-templates", {"templateKey": "incomplete", "name": "Incomplete", "html": "{{ company.legalName }} {{ deal.id }}"}, format="json")
+        self.assertEqual(incomplete.status_code, 400, incomplete.data)
+        self.assertIn("missing required placeholders", incomplete.data["detail"])
+
+    def test_preview_renders_selected_deal_without_creating_a_contract(self):
+        profile = CompanyProfile.objects.create(organization=self.organization, legal_name="ForestIQ & Sons OÜ")
+        template = ContractTemplate.objects.create(
+            organization=self.organization,
+            company_profile=profile,
+            template_key="preview",
+            name="Preview template",
+            html="<p>{{ company.legalName }} / {{ deal.ownerName }} / {{ deal.saleSubject }} / {{ deal.ownerName }}</p>",
+            version=1,
+            created_by=self.admin,
+        )
+        owner = Owner.objects.create(id="55555:001:0001", name="Owner <script>", organization=self.organization)
+        deal = Deal.objects.create(owner=owner, sale_subject="FOREST", organization=self.organization)
+        before_contracts = Contract.objects.count()
+        preview = self.client.post(f"/api/services/contract-templates/{template.id}/preview", {"dealId": str(deal.id)}, format="json")
+        self.assertEqual(preview.status_code, 200, preview.data)
+        self.assertEqual(preview.data["templateId"], str(template.id))
+        self.assertIn("ForestIQ &amp; Sons OÜ", preview.data["html"])
+        self.assertIn("Owner &lt;script&gt;", preview.data["html"])
+        self.assertEqual(preview.data["html"].count("Owner &lt;script&gt;"), 2)
+        self.assertEqual(Contract.objects.count(), before_contracts)
 
 
 class MainParityWorkflowTests(TestCase):

--- a/django_backend/api/urls.py
+++ b/django_backend/api/urls.py
@@ -81,6 +81,8 @@ urlpatterns = [
     path("services/company-profiles", contract_templates.company_profiles),
     path("services/company-profiles/<str:profile_id>", contract_templates.company_profile_detail),
     path("services/contract-templates", contract_templates.contract_templates),
+    path("services/contract-templates/placeholders", contract_templates.contract_template_placeholders),
+    path("services/contract-templates/<str:template_id>/preview", contract_templates.contract_template_preview),
     path("services/contract-templates/<str:template_id>", contract_templates.contract_template_detail),
     path("services/contracts", views.contracts),
     path("services/contracts/generate-from-deal", parity.contract_generate_from_deal),


### PR DESCRIPTION
Closes #30

## Summary
- exposes a server-owned placeholder catalog for contract templates
- rejects unknown, malformed, and missing required placeholders before activation
- renders an escaped HTML preview using the selected organization-scoped deal without storing a contract
- adds API regression coverage and updates the OpenAPI v1 snapshot

## Validation
- `USE_SQLITE_FOR_TESTS=1 python3 manage.py check`
- `python3 -m py_compile api/contract_templates.py api/tests.py api/urls.py`
- full Django/PostGIS test suite runs in Quality Gate