### PR TITLE
feat(contracts): render templates to PDF server-side

### DIFF
--- a/django_backend/api/contract_templates.py
+++ b/django_backend/api/contract_templates.py
@@ -138,15 +138,19 @@ def _template_data(template: ContractTemplate) -> dict:
 
 
 def template_snapshot(template: ContractTemplate) -> dict:
-    """Return immutable data copied onto a contract at generation time."""
+    """Return immutable, JSON-serializable data copied onto a contract at generation time."""
 
+    company = _company_data(template.company_profile) if template.company_profile else None
+    if company:
+        company["createdAt"] = template.company_profile.created_at.isoformat()
+        company["updatedAt"] = template.company_profile.updated_at.isoformat()
     return {
         "templateId": str(template.id),
         "templateKey": template.template_key,
         "version": template.version,
         "name": template.name,
         "html": template.html,
-        "companyProfile": _company_data(template.company_profile) if template.company_profile else None,
+        "companyProfile": company,
     }
 
 

--- a/django_backend/api/contract_templates.py
+++ b/django_backend/api/contract_templates.py
@@ -89,6 +89,13 @@ def _render_preview(template: ContractTemplate, deal: Deal) -> str:
     return PLACEHOLDER_PATTERN.sub(lambda match: escape(values[match.group(1)]), template.html)
 
 
+def render_template_preview_html(template: ContractTemplate, deal: Deal) -> str:
+    """Render the same escaped organization-scoped template used by the preview API."""
+
+    _template_placeholders(template.html)
+    return _render_preview(template, deal)
+
+
 def _detail(message: str, http_status: int = status.HTTP_400_BAD_REQUEST) -> Response:
     return Response({"detail": message}, status=http_status)
 

--- a/django_backend/api/parity.py
+++ b/django_backend/api/parity.py
@@ -38,6 +38,8 @@ from operations.models import (
     Reminder,
 )
 
+from operations.services.contract_pdf import ContractPdfRenderError, render_contract_pdf
+
 from .concurrency import missing_version_response, requested_version, update_if_current, version_conflict_response
 from .permissions import CanEvaluate, CanManageOwners, IsAdmin, can_access_deal, can_access_owner, has_membership_privilege
 from .organization import organization_user_or_404, organization_users, request_organization_id
@@ -1034,6 +1036,14 @@ def contract_generate_from_deal(request):
         template_snapshot = build_template_snapshot(template)
     if Contract.objects.filter(id=contract_id).exists() or ContractHistory.objects.filter(id=contract_id).exists():
         return _detail("A contract with this identifier already exists.", status.HTTP_409_CONFLICT)
+    if template is None:
+        return _detail("templateId is required for server-side PDF generation.")
+    from .contract_templates import render_template_preview_html
+
+    try:
+        pdf_bytes, pdf_sha256 = render_contract_pdf(html=render_template_preview_html(template, deal))
+    except (ContractPdfRenderError, ValueError) as exc:
+        return _detail(str(exc), status.HTTP_422_UNPROCESSABLE_ENTITY)
     with transaction.atomic():
         updated_deal, conflict = _update_deal_or_conflict(request, deal)
         if conflict:
@@ -1047,6 +1057,7 @@ def contract_generate_from_deal(request):
                 "terms": request.data.get("terms", draft["acceptedTerms"]),
                 "contractNumber": contract_number,
                 "template": template_snapshot,
+                "pdfSha256": pdf_sha256,
             },
             cadastres=", ".join(item["cadastralCode"] for item in draft["parcels"]),
         )
@@ -1057,5 +1068,6 @@ def contract_generate_from_deal(request):
             source_offer_id=draft["offerEntryId"],
             template_version=template,
             template_snapshot=template_snapshot,
+            document=pdf_bytes,
         )
-    return Response({"contractId": contract.id, "version": contract.version, "historyId": history.id, "dealId": str(updated_deal.id), "offerEntryId": draft["offerEntryId"], "templateVersionId": str(template.id) if template else None, "pdf": f"/api/services/contracts/{contract.id}/pdf"}, status=status.HTTP_201_CREATED)
+    return Response({"contractId": contract.id, "version": contract.version, "historyId": history.id, "dealId": str(updated_deal.id), "offerEntryId": draft["offerEntryId"], "templateVersionId": str(template.id), "pdf": f"/api/services/contracts/{contract.id}/pdf", "pdfSha256": pdf_sha256}, status=status.HTTP_201_CREATED)

--- a/django_backend/api/tests.py
+++ b/django_backend/api/tests.py
@@ -20,6 +20,7 @@ from api.urls import urlpatterns
 from accounts.models import Organization, OrganizationMembership, OrganizationRole, Privilege, PrivilegeCode, User
 from forestry.models import Cadastre, DataSyncRun, Owner, OwnerStatus
 from operations.models import CompanyProfile, Contract, ContractTemplate, Deal, DealOffer, DealStage, InheritanceCase, Reminder
+from operations.services.contract_pdf import ContractPdfRenderError, render_contract_pdf
 
 
 class RenderCorsTests(TestCase):
@@ -236,6 +237,20 @@ class ContractConfigurationTests(TestCase):
         self.assertEqual(Contract.objects.count(), before_contracts)
 
 
+class ContractPdfServiceTests(SimpleTestCase):
+    def test_estonian_html_with_page_break_has_deterministic_pdf_bytes(self):
+        html = "<h1>Metsamüügi leping ÕÄÖÜ</h1><p>Esimene lehekülg.</p><div class='page-break'></div><p>Teine lehekülg: täpitähed õäöü.</p>"
+        first, first_hash = render_contract_pdf(html=html)
+        second, second_hash = render_contract_pdf(html=html)
+        self.assertTrue(first.startswith(b"%PDF-"))
+        self.assertEqual(first, second)
+        self.assertEqual(first_hash, second_hash)
+
+    def test_empty_html_does_not_produce_a_pdf(self):
+        with self.assertRaises(ContractPdfRenderError):
+            render_contract_pdf(html="")
+
+
 class MainParityWorkflowTests(TestCase):
     def setUp(self):
         self.admin = User.objects.create_superuser("parity-admin", "Parity administrator", "very-secure-admin-password")
@@ -266,11 +281,13 @@ class MainParityWorkflowTests(TestCase):
         self.assertEqual(Deal.objects.get(id=deal_id).offers.get(id=offer_id).status, DealOffer.Status.ACCEPTED)
         draft = self.client.get(f"/api/services/contracts/deals/{deal_id}/draft")
         self.assertEqual(draft.status_code, 200, draft.data)
+        company = CompanyProfile.objects.create(organization=self.admin.default_organization, legal_name="ForestIQ ÕÄÖÜ OÜ")
         template = ContractTemplate.objects.create(
             organization=self.admin.default_organization,
+            company_profile=company,
             template_key="forest-sale",
             name="Metsamüügi leping",
-            html="<h1>{{ buyer }}</h1>",
+            html="<h1>{{ company.legalName }}</h1><p>{{ deal.id }} {{ deal.ownerName }} {{ deal.saleSubject }}</p><div class='page-break'></div><p>ÕÄÖÜ</p>",
             version=1,
             created_by=self.admin,
         )
@@ -280,11 +297,16 @@ class MainParityWorkflowTests(TestCase):
         self.assertEqual(str(saved_contract.source_offer_id), offer_id)
         self.assertEqual(saved_contract.template_version, template)
         self.assertEqual(saved_contract.template_snapshot["version"], 1)
-        self.assertEqual(saved_contract.template_snapshot["html"], "<h1>{{ buyer }}</h1>")
+        self.assertTrue(bytes(saved_contract.document).startswith(b"%PDF-"))
+        self.assertEqual(saved_contract.template_snapshot["html"], "<h1>{{ company.legalName }}</h1><p>{{ deal.id }} {{ deal.ownerName }} {{ deal.saleSubject }}</p><div class='page-break'></div><p>ÕÄÖÜ</p>")
         detail = self.client.get(f"/api/services/contracts/{contract.data['contractId']}")
         self.assertEqual(detail.status_code, 200, detail.data)
         self.assertEqual(detail.data["template"]["templateId"], str(template.id))
-        self.assertEqual(detail.data["template"]["html"], "<h1>{{ buyer }}</h1>")
+        self.assertEqual(detail.data["template"]["html"], "<h1>{{ company.legalName }}</h1><p>{{ deal.id }} {{ deal.ownerName }} {{ deal.saleSubject }}</p><div class='page-break'></div><p>ÕÄÖÜ</p>")
+        pdf = self.client.get(contract.data["pdf"])
+        self.assertEqual(pdf.status_code, 200)
+        self.assertTrue(b"".join(pdf.streaming_content).startswith(b"%PDF-"))
+        self.assertEqual(len(contract.data["pdfSha256"]), 64)
 
     def test_inheritance_case_supports_heir_and_status_workflow(self):
         created = self.client.post(

--- a/django_backend/operations/services/contract_pdf.py
+++ b/django_backend/operations/services/contract_pdf.py
@@ -43,7 +43,10 @@ def render_contract_pdf(*, html: str) -> tuple[bytes, str]:
     if not html or not html.strip():
         raise ContractPdfRenderError("A non-empty HTML contract template is required for PDF rendering.")
     try:
-        pdf = HTML(string=html, base_url=_BASE_URL).write_pdf(stylesheets=[CSS(string=_APPROVED_LAYOUT)])
+        pdf = HTML(string=html, base_url=_BASE_URL).write_pdf(
+            stylesheets=[CSS(string=_APPROVED_LAYOUT)],
+            pdf_identifier=sha256(html.encode("utf-8")).digest(),
+        )
     except Exception as exc:  # WeasyPrint exposes several renderer-specific exception classes.
         raise ContractPdfRenderError("Contract PDF rendering failed; no contract was created.") from exc
     if not pdf.startswith(b"%PDF-") or len(pdf) < 256:

--- a/django_backend/operations/services/contract_pdf.py
+++ b/django_backend/operations/services/contract_pdf.py
@@ -1,0 +1,54 @@
+"""Deterministic server-side rendering for generated contract PDFs."""
+
+from __future__ import annotations
+
+from hashlib import sha256
+from pathlib import Path
+
+from weasyprint import CSS, HTML
+
+
+class ContractPdfRenderError(ValueError):
+    """Raised when a contract cannot be converted to a complete PDF."""
+
+
+_BASE_URL = Path(__file__).resolve().parents[2].as_uri()
+_APPROVED_LAYOUT = """
+@page {
+  size: A4;
+  margin: 20mm 18mm 22mm 18mm;
+  @bottom-center { content: "ForestIQ leping"; font-size: 8pt; color: #4b5563; }
+}
+html { font-family: "DejaVu Serif", serif; font-size: 11pt; color: #111827; }
+body { margin: 0; line-height: 1.45; }
+h1, h2, h3 { color: #164e63; page-break-after: avoid; }
+h1 { font-size: 20pt; margin: 0 0 12pt; }
+h2 { font-size: 14pt; margin: 18pt 0 8pt; }
+p, li { orphans: 3; widows: 3; }
+table { width: 100%; border-collapse: collapse; margin: 10pt 0; }
+th, td { border: 0.5pt solid #94a3b8; padding: 5pt; vertical-align: top; }
+th { background: #e2e8f0; }
+.page-break { break-before: page; }
+"""
+
+
+def render_contract_pdf(*, html: str) -> tuple[bytes, str]:
+    """Render trusted, validated contract HTML to a complete PDF byte string.
+
+    The caller must only persist the returned bytes after this function succeeds.
+    WeasyPrint's deterministic layout and the fixed local DejaVu font ensure that
+    identical template input produces identical page content and pagination.
+    """
+
+    if not html or not html.strip():
+        raise ContractPdfRenderError("A non-empty HTML contract template is required for PDF rendering.")
+    try:
+        pdf = HTML(string=html, base_url=_BASE_URL).write_pdf(stylesheets=[CSS(string=_APPROVED_LAYOUT)])
+    except Exception as exc:  # WeasyPrint exposes several renderer-specific exception classes.
+        raise ContractPdfRenderError("Contract PDF rendering failed; no contract was created.") from exc
+    if not pdf.startswith(b"%PDF-") or len(pdf) < 256:
+        raise ContractPdfRenderError("Contract PDF rendering produced an invalid document; no contract was created.")
+    return pdf, sha256(pdf).hexdigest()
+
+
+__all__ = ["ContractPdfRenderError", "render_contract_pdf"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ requests>=2.32,<3.0
 drf-spectacular==0.28.0
 prometheus-client==0.26.0
 coverage==7.10.7
+weasyprint==69.0


### PR DESCRIPTION
Closes #31

## Summary
- render validated, organization-scoped HTML templates to complete PDF bytes on the server
- use fixed A4 layout, DejaVu Serif Unicode typography, and deterministic page-break CSS
- save PDF bytes only after rendering succeeds inside the contract transaction
- record the final PDF SHA-256 in immutable contract history

## Validation
- `USE_SQLITE_FOR_TESTS=1 python3 manage.py test api.tests.ContractPdfServiceTests --verbosity 2`
- Django system, migration and Python syntax checks
- full Django/PostGIS suite runs in Quality Gate