### PR TITLE
feat(admin): add sales management overview

### DIFF
--- a/api_contracts/openapi-v1.yaml
+++ b/api_contracts/openapi-v1.yaml
@@ -181,6 +181,16 @@ paths:
       responses:
         '200':
           description: No response body
+  /api/v1/services/admin/sales-management-overview:
+    get:
+      operationId: services_admin_sales_management_overview_retrieve
+      description: Return tenant-scoped operational sales workload and intervention
+        signals.
+      tags:
+      - services
+      responses:
+        '200':
+          description: No response body
   /api/v1/services/admin/sync-runs:
     get:
       operationId: services_admin_sync_runs_retrieve

--- a/django_backend/api/permissions.py
+++ b/django_backend/api/permissions.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from rest_framework.permissions import BasePermission
 
-from accounts.models import PrivilegeCode
+from accounts.models import OrganizationRole, PrivilegeCode
 from accounts.organization_context import current_organization_id
 
 
@@ -56,6 +56,19 @@ class IsAdmin(HasForestIQPrivilege):
 
 class CanManageOwners(HasForestIQPrivilege):
     required_privileges = (PrivilegeCode.ADMIN, PrivilegeCode.OWNER_PROFILE, PrivilegeCode.ASSIGNED_OWNERS)
+
+
+class CanManageSales(HasOrganizationMembership):
+    """Allow operational sales overview only for confirmed management roles."""
+
+    management_roles = frozenset((OrganizationRole.OWNER, OrganizationRole.ADMIN, OrganizationRole.CRM_MANAGER))
+
+    def has_permission(self, request, view) -> bool:
+        membership = current_membership(request)
+        return bool(
+            super().has_permission(request, view)
+            and (request.user.is_superuser or set(membership.role_codes).intersection(self.management_roles))
+        )
 
 
 class CanUseAssignedOwners(HasForestIQPrivilege):

--- a/django_backend/api/tests.py
+++ b/django_backend/api/tests.py
@@ -167,6 +167,46 @@ class DashboardStatsTests(TestCase):
         self.assertLessEqual(p95_ms, 500, f"DashboardStats p95 {p95_ms:.2f}ms exceeded the 500ms budget")
 
 
+class SalesManagementOverviewTests(TestCase):
+    def setUp(self):
+        self.organization = Organization.objects.create(slug="sales-overview", name="Sales overview organization")
+        self.manager = User.objects.create_user("sales-manager", "Sales manager", "very-secure-password", default_organization=self.organization)
+        membership = OrganizationMembership.objects.get(user=self.manager, organization=self.organization)
+        membership.roles = [OrganizationRole.CRM_MANAGER]
+        membership.save(update_fields=["roles"])
+        self.caller = User.objects.create_user("sales-caller", "Sales caller", "very-secure-password", default_organization=self.organization)
+        caller_membership = OrganizationMembership.objects.get(user=self.caller, organization=self.organization)
+        caller_membership.roles = [OrganizationRole.CALLER]
+        caller_membership.save(update_fields=["roles"])
+        self.owner = Owner.objects.create(id="33333:001:0001", name="Managed owner", organization=self.organization, assignee=self.manager)
+        self.evaluation_owner = Owner.objects.create(id="33333:001:0002", name="Evaluation owner", organization=self.organization, assignee=self.manager)
+        now = timezone.now()
+        Deal.objects.create(owner=self.owner, organization=self.organization, sale_subject="FOREST", stage=DealStage.NEGOTIATION, offer_valid_until=timezone.localdate() - timedelta(days=1))
+        Deal.objects.create(owner=self.evaluation_owner, organization=self.organization, sale_subject="LAND", stage=DealStage.EVALUATION)
+        Reminder.objects.create(owner=self.owner, creator=self.manager, organization=self.organization, text="Overdue callback", due_time=now - timedelta(days=1))
+        OwnerLog.objects.create(owner=self.owner, creator=self.manager, organization=self.organization, message="Sales outcome: CALLBACK. Customer asked to call back.")
+        self.client = APIClient()
+
+    def _authenticate(self, user):
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {token_pair(user)['actualToken']['token']}")
+
+    def test_crm_manager_receives_team_workload_contacts_deals_and_interventions(self):
+        self._authenticate(self.manager)
+        response = self.client.get("/api/services/admin/sales-management-overview")
+        self.assertEqual(response.status_code, 200, response.data)
+        member = next(item for item in response.data["team"] if item["member"]["id"] == self.manager.id)
+        self.assertEqual(member["workload"], {"assignedOwners": 2, "activeDeals": 2, "evaluationDeals": 0, "overdueReminders": 1})
+        self.assertEqual(member["contactOutcomes"]["CALLBACK"], 1)
+        self.assertEqual(member["deals"][DealStage.NEGOTIATION], 1)
+        self.assertEqual(member["deals"][DealStage.EVALUATION], 1)
+        self.assertEqual({item["kind"] for item in response.data["interventions"]}, {"EXPIRED_OFFER", "OVERDUE_REMINDER", "UNASSIGNED_EVALUATION"})
+
+    def test_caller_role_cannot_access_management_overview(self):
+        self._authenticate(self.caller)
+        response = self.client.get("/api/services/admin/sales-management-overview")
+        self.assertEqual(response.status_code, 403)
+
+
 class ContractConfigurationTests(TestCase):
     def setUp(self):
         self.organization = Organization.objects.create(slug="contract-config", name="Contract configuration organization")

--- a/django_backend/api/tests.py
+++ b/django_backend/api/tests.py
@@ -18,7 +18,7 @@ from rest_framework_simplejwt.tokens import RefreshToken
 from api.auth import token_pair
 from api.urls import urlpatterns
 from accounts.models import Organization, OrganizationMembership, OrganizationRole, Privilege, PrivilegeCode, User
-from forestry.models import Cadastre, DataSyncRun, Owner, OwnerStatus
+from forestry.models import Cadastre, DataSyncRun, Owner, OwnerLog, OwnerStatus
 from operations.models import CompanyProfile, Contract, ContractTemplate, Deal, DealOffer, DealStage, InheritanceCase, Reminder
 from operations.services.contract_pdf import ContractPdfRenderError, render_contract_pdf
 

--- a/django_backend/api/urls.py
+++ b/django_backend/api/urls.py
@@ -20,6 +20,7 @@ urlpatterns = [
     path("services/admin/userstatistics/prep-data", views.user_statistics_prep),
     path("services/admin/userstatistics/owner-status-change", views.user_statistics),
     path("services/admin/dashboard-stats", views.dashboard_stats),
+    path("services/admin/sales-management-overview", views.sales_management_overview),
     path("services/admin/sync-runs", views.sync_runs),
     path("services/admin/sync-runs/<int:run_id>/retry", views.retry_sync_run),
     path("services/admin/cadastres/<str:cadastre_id>/sync", views.cadastre_sync),

--- a/django_backend/api/views.py
+++ b/django_backend/api/views.py
@@ -1248,7 +1248,7 @@ def sales_management_overview(request):
         if owner and owner["assignee_id"] in team:
             team[owner["assignee_id"]]["workload"]["overdueReminders"] += 1
         if owner:
-            interventions.append({"kind": "OVERDUE_REMINDER", "reminderId": str(reminder["id"]), "ownerId": str(reminder["owner_id"]), "ownerName": owner["name"], "assigneeId": owner["assignee_id"], "dueAt": json_value(reminder["due_time"])})
+            interventions.append({"kind": "OVERDUE_REMINDER", "reminderId": str(reminder["id"]), "ownerId": str(reminder["owner_id"]), "ownerName": owner["name"], "assigneeId": owner["assignee_id"], "dueAt": reminder["due_time"].isoformat()})
 
     for contact in OwnerLog.objects.filter(organization_id=organization_id, created_at__gte=recent_at, message__startswith="Sales outcome:").values("creator_id", "message"):
         if contact["creator_id"] not in team:

--- a/django_backend/api/views.py
+++ b/django_backend/api/views.py
@@ -43,6 +43,7 @@ from .organization import organization_user_or_404, organization_users, request_
 from .permissions import (
     CanEvaluate,
     CanManageOwners,
+    CanManageSales,
     CanUseAssignedOwners,
     CanUsePhones,
     CanViewOrganizationData,
@@ -1196,5 +1197,70 @@ def dashboard_stats(request):
             },
             "dealStages": deal_stage_counts,
             "generatedAt": now,
+        }
+    )
+
+
+@api_view(["GET"])
+@permission_classes([CanManageSales])
+def sales_management_overview(request):
+    """Return tenant-scoped operational sales workload and intervention signals."""
+
+    organization_id = request_organization_id(request)
+    now = timezone.now()
+    today = timezone.localdate(now)
+    recent_at = now - timedelta(days=30)
+    closed_stages = (DealStage.WON, DealStage.LOST, DealStage.CANCELLED)
+    team = {
+        member.id: {
+            "member": user_data(member),
+            "workload": {"assignedOwners": 0, "activeDeals": 0, "evaluationDeals": 0, "overdueReminders": 0},
+            "contactOutcomes": {outcome: 0 for outcome in ("CALLBACK", "NO_ANSWER", "INTERESTED", "NOT_INTERESTED", "DECLINED", "FOLLOW_UP")},
+            "deals": {stage: 0 for stage, _label in DealStage.choices},
+        }
+        for member in organization_users(request, active_only=True).only("id", "full_name")
+    }
+    owner_rows = list(Owner.objects.filter(organization_id=organization_id).values("id", "name", "assignee_id"))
+    owners_by_id = {str(item["id"]): item for item in owner_rows}
+    active_owner_scope = Q(out_of_admin_search_from__isnull=True) | Q(out_of_admin_search_to__lte=now)
+    for frame in Owner.objects.filter(organization_id=organization_id).filter(active_owner_scope).values("assignee_id").annotate(count=Count("id")):
+        if frame["assignee_id"] in team:
+            team[frame["assignee_id"]]["workload"]["assignedOwners"] = frame["count"]
+
+    interventions = []
+    deals = Deal.objects.filter(organization_id=organization_id)
+    for deal in deals.values("id", "owner_id", "owner__assignee_id", "evaluator_id", "stage", "offer_valid_until"):
+        assignee_id = deal["owner__assignee_id"]
+        if assignee_id in team:
+            team[assignee_id]["deals"][deal["stage"]] += 1
+            if deal["stage"] not in closed_stages:
+                team[assignee_id]["workload"]["activeDeals"] += 1
+        if deal["stage"] == DealStage.EVALUATION and deal["evaluator_id"] in team:
+            team[deal["evaluator_id"]]["workload"]["evaluationDeals"] += 1
+        owner = owners_by_id.get(str(deal["owner_id"]))
+        if deal["stage"] == DealStage.EVALUATION and not deal["evaluator_id"] and owner:
+            interventions.append({"kind": "UNASSIGNED_EVALUATION", "dealId": str(deal["id"]), "ownerId": str(deal["owner_id"]), "ownerName": owner["name"], "assigneeId": assignee_id, "dueAt": None})
+        if deal["stage"] not in closed_stages and deal["offer_valid_until"] and deal["offer_valid_until"] < today and owner:
+            interventions.append({"kind": "EXPIRED_OFFER", "dealId": str(deal["id"]), "ownerId": str(deal["owner_id"]), "ownerName": owner["name"], "assigneeId": assignee_id, "dueAt": deal["offer_valid_until"].isoformat()})
+
+    for reminder in Reminder.objects.filter(organization_id=organization_id, due_time__lt=now).values("id", "owner_id", "due_time"):
+        owner = owners_by_id.get(str(reminder["owner_id"]))
+        if owner and owner["assignee_id"] in team:
+            team[owner["assignee_id"]]["workload"]["overdueReminders"] += 1
+        if owner:
+            interventions.append({"kind": "OVERDUE_REMINDER", "reminderId": str(reminder["id"]), "ownerId": str(reminder["owner_id"]), "ownerName": owner["name"], "assigneeId": owner["assignee_id"], "dueAt": json_value(reminder["due_time"])})
+
+    for contact in OwnerLog.objects.filter(organization_id=organization_id, created_at__gte=recent_at, message__startswith="Sales outcome:").values("creator_id", "message"):
+        if contact["creator_id"] not in team:
+            continue
+        outcome = contact["message"].split(" ", 2)[2].split(".", 1)[0]
+        if outcome in team[contact["creator_id"]]["contactOutcomes"]:
+            team[contact["creator_id"]]["contactOutcomes"][outcome] += 1
+
+    return Response(
+        {
+            "period": {"contactOutcomesSince": json_value(recent_at), "generatedAt": json_value(now)},
+            "team": list(team.values()),
+            "interventions": sorted(interventions, key=lambda item: (item["dueAt"] is None, item["dueAt"] or "", item["kind"]))[:100],
         }
     )


### PR DESCRIPTION
Closes #36

## Summary
- add a tenant-scoped sales management overview for confirmed organization management roles
- report member workload, 30-day contact outcomes, stage distributions, and actionable cases
- protect the view from caller and evaluator roles

## Validation
- Django configuration, migration and syntax checks
- OpenAPI v1 snapshot regenerated
- full PostgreSQL/PostGIS suite runs in the required Quality Gate