### PR TITLE
fix(contracts): stabilize deterministic PDF rendering

### DIFF
--- a/django_backend/operations/services/contract_pdf.py
+++ b/django_backend/operations/services/contract_pdf.py
@@ -37,7 +37,9 @@ def render_contract_pdf(*, html: str) -> tuple[bytes, str]:
 
     The caller must only persist the returned bytes after this function succeeds.
     WeasyPrint's deterministic layout and the fixed local DejaVu font ensure that
-    identical template input produces identical page content and pagination.
+    identical template input produces identical page content and pagination. The
+    output remains uncompressed so renderer-specific stream compression cannot
+    introduce byte-level differences in the auditable artifact.
     """
 
     if not html or not html.strip():
@@ -46,6 +48,7 @@ def render_contract_pdf(*, html: str) -> tuple[bytes, str]:
         pdf = HTML(string=html, base_url=_BASE_URL).write_pdf(
             stylesheets=[CSS(string=_APPROVED_LAYOUT)],
             pdf_identifier=sha256(html.encode("utf-8")).digest(),
+            uncompressed_pdf=True,
         )
     except Exception as exc:  # WeasyPrint exposes several renderer-specific exception classes.
         raise ContractPdfRenderError("Contract PDF rendering failed; no contract was created.") from exc


### PR DESCRIPTION
## Kokkuvõte

- Lepingute PDF-id renderdatakse tihendamata kujul, et kõrvaldada vootihendusest tulenev baitide varieeruvus.
- Säilivad olemasolev HTML-sisupõhine PDF-identifikaator ning A4/DejaVu Serif kujundus.
- Eesti täpitähtedega kaheleheküljelise PDF-i determinismi regressioonitest läbib korduvalt.

## Kontrollid

- `USE_SQLITE_FOR_TESTS=1 python3 manage.py check`
- `USE_SQLITE_FOR_TESTS=1 python3 manage.py test api.tests.ContractPdfServiceTests --verbosity 0`
- Deterministlik PDF-test käivitati järjest viis korda.

See parandab ADM-02 valideerimisel avastatud CON-03 regressiooni.
