### PR TITLE
feat(admin): filter user status statistics

### DIFF
--- a/api_contracts/openapi-v1.yaml
+++ b/api_contracts/openapi-v1.yaml
@@ -261,6 +261,36 @@ paths:
   /api/v1/services/admin/userstatistics/owner-status-change:
     get:
       operationId: services_admin_userstatistics_owner_status_change_retrieve
+      description: Return tenant-scoped owner-status changes grouped at the requested
+        cadence.
+      parameters:
+      - in: query
+        name: from
+        schema:
+          type: string
+          format: date-time
+        description: Inclusive ISO-8601 start date or datetime.
+      - in: query
+        name: fromStatus
+        schema:
+          type: string
+        description: Filter by the previous owner status.
+      - in: query
+        name: granularity
+        schema:
+          type: string
+        description: 'Aggregation cadence: hour, day, week, or month.'
+      - in: query
+        name: to
+        schema:
+          type: string
+          format: date-time
+        description: Inclusive ISO-8601 end date or datetime.
+      - in: query
+        name: toStatus
+        schema:
+          type: string
+        description: Filter by the new owner status.
       tags:
       - services
       responses:

--- a/django_backend/api/tests.py
+++ b/django_backend/api/tests.py
@@ -18,7 +18,7 @@ from rest_framework_simplejwt.tokens import RefreshToken
 from api.auth import token_pair
 from api.urls import urlpatterns
 from accounts.models import Organization, OrganizationMembership, OrganizationRole, Privilege, PrivilegeCode, User
-from forestry.models import Cadastre, DataSyncRun, Owner, OwnerLog, OwnerStatus
+from forestry.models import Cadastre, DataSyncRun, Owner, OwnerLog, OwnerStatus, OwnerStatusChange
 from operations.models import CompanyProfile, Contract, ContractTemplate, Deal, DealOffer, DealStage, InheritanceCase, Reminder
 from operations.services.contract_pdf import ContractPdfRenderError, render_contract_pdf
 

--- a/django_backend/api/tests.py
+++ b/django_backend/api/tests.py
@@ -123,6 +123,47 @@ class AdminWorkflowTests(TestCase):
         self.assertEqual(owner.status, "ASSIGNED")
 
 
+class UserStatisticsTests(TestCase):
+    def setUp(self):
+        self.organization = Organization.objects.create(slug="statistics-org", name="Statistics organization")
+        self.other_organization = Organization.objects.create(slug="statistics-other", name="Other statistics organization")
+        self.admin = User.objects.create_user("statistics-admin", "Statistics administrator", "very-secure-admin-password", default_organization=self.organization)
+        Privilege.objects.create(user=self.admin, code=PrivilegeCode.ADMIN)
+        self.other_user = User.objects.create_user("statistics-other-user", "Other statistics user", "very-secure-password", default_organization=self.other_organization)
+        self.client = APIClient()
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {token_pair(self.admin)['actualToken']['token']}")
+        first = OwnerStatusChange.objects.create(user=self.admin, from_status="NEW", to_status="ASSIGNED", organization=self.organization)
+        second = OwnerStatusChange.objects.create(user=self.admin, from_status="ASSIGNED", to_status="IN_PROGRESS", organization=self.organization)
+        other = OwnerStatusChange.objects.create(user=self.other_user, from_status="NEW", to_status="ASSIGNED", organization=self.other_organization)
+        now = timezone.now().replace(minute=30, second=0, microsecond=0)
+        OwnerStatusChange.objects.filter(id=first.id).update(timestamp=now - timedelta(days=2))
+        OwnerStatusChange.objects.filter(id=second.id).update(timestamp=now - timedelta(hours=2))
+        OwnerStatusChange.objects.filter(id=other.id).update(timestamp=now - timedelta(hours=1))
+
+    def test_statistics_filter_by_time_and_status_is_organization_scoped(self):
+        response = self.client.get(
+            "/api/services/admin/userstatistics/owner-status-change",
+            {"from": (timezone.localdate() - timedelta(days=3)).isoformat(), "to": timezone.localdate().isoformat(), "fromStatus": "NEW", "toStatus": "ASSIGNED", "granularity": "day"},
+        )
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(response.data, [{"userId": self.admin.id, "statisticsFrames": [{"since": response.data[0]["statisticsFrames"][0]["since"], "count": 1}]}])
+
+    def test_statistics_supports_each_requested_granularity(self):
+        for granularity in ("hour", "day", "week", "month"):
+            response = self.client.get("/api/services/admin/userstatistics/owner-status-change", {"granularity": granularity})
+            self.assertEqual(response.status_code, 200, {"granularity": granularity, "data": response.data})
+            self.assertEqual(response.data[0]["userId"], self.admin.id)
+            self.assertTrue(response.data[0]["statisticsFrames"])
+
+    def test_statistics_rejects_invalid_query_parameters(self):
+        invalid_granularity = self.client.get("/api/services/admin/userstatistics/owner-status-change", {"granularity": "quarter"})
+        self.assertEqual(invalid_granularity.status_code, 400)
+        self.assertIn("granularity", invalid_granularity.data["detail"])
+        invalid_range = self.client.get("/api/services/admin/userstatistics/owner-status-change", {"from": "2026-08-02", "to": "2026-08-01"})
+        self.assertEqual(invalid_range.status_code, 400)
+        self.assertIn("from must be before to", invalid_range.data["detail"])
+
+
 class DashboardStatsTests(TestCase):
     def setUp(self):
         self.organization = Organization.objects.create(slug="dashboard-org", name="Dashboard organization")

--- a/django_backend/api/views.py
+++ b/django_backend/api/views.py
@@ -12,6 +12,7 @@ from uuid import uuid4
 from django.conf import settings
 from django.db import connection, transaction
 from django.db.models import Count, Q, Sum
+from django.db.models.functions import TruncDay, TruncHour, TruncMonth, TruncWeek
 from django.contrib.gis.geos import Polygon
 from django.http import FileResponse, HttpResponse
 from django.shortcuts import get_object_or_404
@@ -20,6 +21,7 @@ from django.utils.dateparse import parse_datetime
 from rest_framework import status
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.response import Response
+from drf_spectacular.utils import OpenApiParameter, OpenApiTypes, extend_schema
 
 from accounts.models import Privilege, PrivilegeCode, User
 from accounts.authorization import sync_user_groups
@@ -71,6 +73,22 @@ from forestry.services.tile_cache import cache_vector_tile, get_cached_vector_ti
 
 def _detail(message: str, http_status: int = status.HTTP_400_BAD_REQUEST) -> Response:
     return Response({"detail": message}, status=http_status)
+
+
+def _statistics_boundary(value: str | None, *, parameter: str, inclusive_day_end: bool = False) -> datetime | None:
+    if not value:
+        return None
+    parsed = parse_datetime(value)
+    if parsed is None:
+        try:
+            parsed = datetime.fromisoformat(value)
+        except ValueError as exc:
+            raise ValueError(f"{parameter} must be an ISO-8601 date or datetime.") from exc
+        if inclusive_day_end and len(value) == 10:
+            parsed += timedelta(days=1)
+    if timezone.is_naive(parsed):
+        parsed = timezone.make_aware(parsed, timezone.get_current_timezone())
+    return parsed
 
 
 def _sync_run_data(run: DataSyncRun) -> dict:
@@ -1147,15 +1165,49 @@ def user_statistics_prep(request):
     return Response({"users": [user_data(user) for user in organization_users(request, active_only=True)], "statuses": list(OwnerStatus.objects.values_list("id", flat=True))})
 
 
+@extend_schema(
+    parameters=[
+        OpenApiParameter("from", OpenApiTypes.DATETIME, OpenApiParameter.QUERY, description="Inclusive ISO-8601 start date or datetime."),
+        OpenApiParameter("to", OpenApiTypes.DATETIME, OpenApiParameter.QUERY, description="Inclusive ISO-8601 end date or datetime."),
+        OpenApiParameter("fromStatus", OpenApiTypes.STR, OpenApiParameter.QUERY, description="Filter by the previous owner status."),
+        OpenApiParameter("toStatus", OpenApiTypes.STR, OpenApiParameter.QUERY, description="Filter by the new owner status."),
+        OpenApiParameter("granularity", OpenApiTypes.STR, OpenApiParameter.QUERY, description="Aggregation cadence: hour, day, week, or month."),
+    ]
+)
 @api_view(["GET"])
 @permission_classes([IsAdmin])
 def user_statistics(request):
-    frames = (
-        OwnerStatusChange.objects.values("user_id")
-        .annotate(count=Count("id"))
-        .order_by("user_id")
-    )
-    return Response([{"userId": frame["user_id"], "statisticsFrames": [{"since": None, "count": frame["count"]}]} for frame in frames])
+    """Return tenant-scoped owner-status changes grouped at the requested cadence."""
+
+    granularity = request.query_params.get("granularity", "day").lower()
+    truncators = {"hour": TruncHour, "day": TruncDay, "week": TruncWeek, "month": TruncMonth}
+    if granularity not in truncators:
+        return _detail("granularity must be one of: hour, day, week, month.")
+    try:
+        from_at = _statistics_boundary(request.query_params.get("from"), parameter="from")
+        to_at = _statistics_boundary(request.query_params.get("to"), parameter="to", inclusive_day_end=True)
+    except ValueError as exc:
+        return _detail(str(exc))
+    if from_at and to_at and from_at >= to_at:
+        return _detail("from must be before to.")
+
+    changes = OwnerStatusChange.objects.filter(organization_id=request_organization_id(request))
+    if from_at:
+        changes = changes.filter(timestamp__gte=from_at)
+    if to_at:
+        changes = changes.filter(timestamp__lt=to_at)
+    from_status = request.query_params.get("fromStatus")
+    to_status = request.query_params.get("toStatus")
+    if from_status:
+        changes = changes.filter(from_status=from_status)
+    if to_status:
+        changes = changes.filter(to_status=to_status)
+
+    frames = changes.annotate(since=truncators[granularity]("timestamp")).values("user_id", "since").annotate(count=Count("id")).order_by("user_id", "since")
+    grouped: dict[str, list[dict]] = {}
+    for frame in frames:
+        grouped.setdefault(frame["user_id"], []).append({"since": json_value(frame["since"]), "count": frame["count"]})
+    return Response([{"userId": user_id, "statisticsFrames": values} for user_id, values in grouped.items()])
 
 
 @api_view(["GET"])


### PR DESCRIPTION
## Kokkuvõte

See muudatus laiendab kasutajate staatusemuudatuste statistika API-t päringuparameetritega `from`, `to`, `fromStatus`, `toStatus` ja `granularity`. Toetatud granulaarsused on `hour`, `day`, `week` ja `month`; kõik päringud on piiratud aktiivse organisatsiooniga ning tulemuste põhikuju säilib.

Vigased ajavahemikud, kuupäevad ja granulaarsused tagastavad ühtse 400-vastuse. Versioonitud OpenAPI snapshot dokumenteerib kõik uued päringuparameetrid. Lisatud testid katavad organisatsiooni isolatsiooni, aja- ja staatusefiltrid, kõik granulaarsused ning sisendite valideerimise.

## Kontrollid

| Kontroll | Tulemus |
|---|---|
| `USE_SQLITE_FOR_TESTS=1 python3 manage.py check` | Läbis |
| `python3 -m py_compile api/views.py api/tests.py` | Läbis |
| `makemigrations --check --dry-run` | Läbis |
| OpenAPI snapshoti genereerimine ja valideerimine | Läbis |
| Sihttest `UserStatisticsTests` SQLite’is | Ei ole käivitatav olemasolevate GeoDjango/PostGIS migratsioonide tõttu; PR-i kohustuslik kvaliteedivärav käivitab päris PostGIS-i komplekti |

Closes #38.
