### PR TITLE
feat(integrations): add declarative job registry

### DIFF
--- a/django_backend/api/integrations.py
+++ b/django_backend/api/integrations.py
@@ -1,0 +1,156 @@
+"""Declarative adapters for administrator-managed external integration work."""
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from django.conf import settings
+
+from forestry.models import DataSyncRun
+from forestry.tasks import enqueue_cadastre_sync, enqueue_portfolio_sync, run_parimus_official_notice_import
+
+from .organization import request_organization_id
+from .serializers import json_value
+
+
+@dataclass(frozen=True)
+class IntegrationDispatch:
+    payload: dict[str, Any]
+    status_code: int
+
+
+@dataclass(frozen=True)
+class IntegrationAdapter:
+    """One registered integration and its complete operational declaration."""
+
+    key: str
+    label: str
+    mode: str
+    source_token: str
+    configured: Callable[[], bool]
+    dispatch: Callable[[Any], IntegrationDispatch] | None = None
+
+    def records(self, organization_id: str):
+        return DataSyncRun.objects.filter(organization_id=organization_id, source__icontains=self.source_token).order_by("-id")
+
+    def latest(self, organization_id: str) -> DataSyncRun | None:
+        return self.records(organization_id).first()
+
+    def health(self, latest: DataSyncRun | None) -> str:
+        if not self.configured():
+            return "UNCONFIGURED"
+        if latest is None:
+            return "UNKNOWN"
+        if latest.status in {DataSyncRun.Status.FAILED, DataSyncRun.Status.PARTIAL}:
+            return "DEGRADED"
+        if latest.status in {DataSyncRun.Status.QUEUED, DataSyncRun.Status.RUNNING}:
+            return "PENDING"
+        return "OK"
+
+    def row(self, organization_id: str) -> dict[str, Any]:
+        latest = self.latest(organization_id)
+        return {
+            "key": self.key,
+            "label": self.label,
+            "configured": self.configured(),
+            "mode": self.mode,
+            "status": latest.status if latest else "NOT_RUN",
+            "checkpoint": latest.cursor if latest else None,
+            "health": self.health(latest),
+            "lastRun": serialize_run(latest) if latest else None,
+        }
+
+
+def serialize_run(item: DataSyncRun) -> dict[str, Any]:
+    """Serialize durable run evidence consistently for every registered adapter."""
+
+    return {
+        "id": item.id,
+        "cadastreId": item.cadastre_id,
+        "source": item.source,
+        "status": item.status,
+        "taskId": item.task_id,
+        "correlationId": item.correlation_id or None,
+        "pagesProcessed": item.pages_processed,
+        "rowsProcessed": item.rows_processed,
+        "retryCount": item.retry_count,
+        "backlogSize": item.backlog_size,
+        "cursor": item.cursor,
+        "lagSeconds": item.lag_seconds,
+        "retryOf": item.retry_of_id,
+        "startedAt": json_value(item.started_at),
+        "finishedAt": json_value(item.finished_at),
+        "result": item.result,
+        "error": item.error_message or None,
+    }
+
+
+def _cadastre_dispatch(request) -> IntegrationDispatch:
+    organization_id = str(request_organization_id(request))
+    parameters = request.data.get("parameters", {})
+    parameters = parameters if isinstance(parameters, dict) else {}
+    cadastre_id = str(request.data.get("cadastreId") or parameters.get("cadastreId") or "").strip()
+    if cadastre_id:
+        dispatch = enqueue_cadastre_sync(
+            cadastre_id,
+            organization_id=organization_id,
+            requested_by_id=request.user.id,
+            source="cadastre",
+        )
+        if dispatch.already_running:
+            run = dispatch.run
+            return IntegrationDispatch(
+                {"key": "CADASTRE", "status": "already_running", "code": "already_running", "runId": run.id if run else None, "taskId": run.task_id if run else "", "correlationId": run.correlation_id if run else None},
+                409,
+            )
+        run = dispatch.run
+        return IntegrationDispatch(
+            {"key": "CADASTRE", "status": run.status, "runId": run.id, "taskId": run.task_id, "correlationId": run.correlation_id or None},
+            202,
+        )
+    if settings.FORESTIQ_TASKS_INLINE:
+        result = enqueue_portfolio_sync(organization_id)
+        return IntegrationDispatch({"key": "CADASTRE", "status": "SUCCESS", "result": result}, 202)
+    task = enqueue_portfolio_sync.delay(organization_id)
+    return IntegrationDispatch({"key": "CADASTRE", "status": "QUEUED", "taskId": task.id}, 202)
+
+
+def _parimus_dispatch(request) -> IntegrationDispatch:
+    organization_id = str(request_organization_id(request))
+    if settings.FORESTIQ_TASKS_INLINE:
+        result = run_parimus_official_notice_import.run(organization_id)
+        return IntegrationDispatch({"key": "PARIMUS", "status": result.get("status", "SUCCESS"), "result": result}, 202)
+    task = run_parimus_official_notice_import.delay(organization_id)
+    return IntegrationDispatch({"key": "PARIMUS", "status": "QUEUED", "taskId": task.id}, 202)
+
+
+def _forestek_dispatch(_request) -> IntegrationDispatch:
+    return IntegrationDispatch(
+        {"detail": "Forestek is a one-time initial import. Run the controlled management command only before its first successful import."},
+        409,
+    )
+
+
+class IntegrationRegistry:
+    def __init__(self, adapters: tuple[IntegrationAdapter, ...]):
+        self._adapters = adapters
+        self._by_key = {adapter.key: adapter for adapter in adapters}
+
+    def all(self) -> tuple[IntegrationAdapter, ...]:
+        return self._adapters
+
+    def get(self, key: str) -> IntegrationAdapter | None:
+        return self._by_key.get(key.upper())
+
+    def rows(self, organization_id: str) -> list[dict[str, Any]]:
+        return [adapter.row(organization_id) for adapter in self._adapters]
+
+
+integration_registry = IntegrationRegistry(
+    (
+        IntegrationAdapter("CADASTRE", "Cadastre and forest registry", "RECURRING", "cadastre", lambda: True, _cadastre_dispatch),
+        IntegrationAdapter("FORESTEK", "Forestek ownership relations", "ONE_TIME", "forestek", lambda: bool(settings.FORESTEK_API_URL and settings.FORESTEK_API_TOKEN), _forestek_dispatch),
+        IntegrationAdapter("PARIMUS", "Pärimus official notices", "RECURRING", "parimus", lambda: bool(settings.PARIMUS_API_URL and settings.PARIMUS_API_TOKEN), _parimus_dispatch),
+    )
+)

--- a/django_backend/api/parity.py
+++ b/django_backend/api/parity.py
@@ -22,7 +22,7 @@ from rest_framework.response import Response
 
 from accounts.models import PrivilegeCode, User
 from forestry.models import Cadastre, DataSyncRun, InheritanceSignal, Owner, OwnerLog
-from forestry.tasks import enqueue_cadastre_sync, enqueue_portfolio_sync
+from forestry.tasks import enqueue_cadastre_sync
 from operations.models import (
     Contract,
     ContractHistory,
@@ -42,6 +42,7 @@ from operations.services.contract_pdf import ContractPdfRenderError, render_cont
 
 from .concurrency import missing_version_response, requested_version, update_if_current, version_conflict_response
 from .permissions import CanEvaluate, CanManageOwners, IsAdmin, can_access_deal, can_access_owner, has_membership_privilege
+from .integrations import integration_registry, serialize_run
 from .organization import organization_user_or_404, organization_users, request_organization_id
 from .serializers import cadastre_summary, json_value, owner_summary, user_data
 
@@ -787,96 +788,56 @@ def ownership_transition_events(request, owner_id: str):
 
 
 def _integration_run_data(item: DataSyncRun) -> dict:
-    """Serialize the complete durable integration audit without hidden retry state."""
+    """Backward-compatible name for the registry's durable audit serializer."""
 
-    return {
-        "id": item.id,
-        "cadastreId": item.cadastre_id,
-        "source": item.source,
-        "status": item.status,
-        "taskId": item.task_id,
-        "correlationId": item.correlation_id or None,
-        "pagesProcessed": item.pages_processed,
-        "rowsProcessed": item.rows_processed,
-        "retryCount": item.retry_count,
-        "backlogSize": item.backlog_size,
-        "cursor": item.cursor,
-        "lagSeconds": item.lag_seconds,
-        "retryOf": item.retry_of_id,
-        "startedAt": json_value(item.started_at),
-        "finishedAt": json_value(item.finished_at),
-        "result": item.result,
-        "error": item.error_message or None,
-    }
-
-
-def _integration_rows() -> list[dict]:
-    rows = []
-    for key, label, configured in [("CADASTRE", "Cadastre and forest registry", True), ("FORESTEK", "Forestek ownership relations", bool(settings.FORESTEK_API_URL and settings.FORESTEK_API_TOKEN)), ("PARIMUS", "Pärimus official notices", bool(settings.PARIMUS_API_URL and settings.PARIMUS_API_TOKEN))]:
-        latest = DataSyncRun.objects.filter(source__icontains=key.lower()).order_by("-id").first()
-        rows.append({"key": key, "label": label, "configured": configured, "mode": "ONE_TIME" if key == "FORESTEK" else "RECURRING", "lastRun": {"id": latest.id, "status": latest.status, "finishedAt": json_value(latest.finished_at), "error": latest.error_message or None} if latest else None})
-    return rows
+    return serialize_run(item)
 
 
 @api_view(["GET"])
 @permission_classes([IsAdmin])
 def integration_jobs(request):
-    return Response(_integration_rows())
+    return Response(integration_registry.rows(str(request_organization_id(request))))
 
 
 @api_view(["GET", "POST"])
 @permission_classes([IsAdmin])
 def integration_start(request, key: str):
-    key = key.upper()
-    if key not in {"CADASTRE", "FORESTEK", "PARIMUS"}:
+    adapter = integration_registry.get(key)
+    if adapter is None:
         return _detail("Unknown integration key.", status.HTTP_404_NOT_FOUND)
+    organization_id = str(request_organization_id(request))
     if request.method == "GET":
-        limit = min(max(int(request.query_params.get("limit", "10")), 1), 100)
-        records = DataSyncRun.objects.filter(source__icontains=key.lower()).order_by("-id")[:limit]
-        return Response([_integration_run_data(item) for item in records])
-    if key == "FORESTEK":
-        return _detail("Forestek is a one-time initial import. Run the controlled management command only before its first successful import.", status.HTTP_409_CONFLICT)
-    cadastre_id = request.data.get("cadastreId") or request.data.get("parameters", {}).get("cadastreId")
-    if cadastre_id:
-        dispatch = enqueue_cadastre_sync(
-            str(cadastre_id),
-            organization_id=str(request_organization_id(request)),
-            requested_by_id=request.user.id,
-            source=key.lower(),
-        )
-        if dispatch.already_running:
-            return Response(
-                {
-                    "key": key,
-                    "status": "already_running",
-                    "code": "already_running",
-                    "runId": dispatch.run.id if dispatch.run else None,
-                    "taskId": dispatch.run.task_id if dispatch.run else "",
-                    "correlationId": dispatch.run.correlation_id if dispatch.run else None,
-                },
-                status=status.HTTP_409_CONFLICT,
-            )
-        return Response({"key": key, "status": dispatch.run.status, "runId": dispatch.run.id, "taskId": dispatch.run.task_id, "correlationId": dispatch.run.correlation_id or None}, status=status.HTTP_202_ACCEPTED)
-    if settings.FORESTIQ_TASKS_INLINE:
-        result = enqueue_portfolio_sync(str(request_organization_id(request)))
-        return Response({"key": key, "status": "SUCCESS", "result": result})
-    task = enqueue_portfolio_sync.delay(str(request_organization_id(request)))
-    return Response({"key": key, "status": "QUEUED", "taskId": task.id}, status=status.HTTP_202_ACCEPTED)
+        try:
+            limit = min(max(int(request.query_params.get("limit", "10")), 1), 100)
+        except ValueError:
+            return _detail("limit must be an integer between 1 and 100.")
+        return Response([serialize_run(item) for item in adapter.records(organization_id)[:limit]])
+    if adapter.mode != "ONE_TIME" and not adapter.configured():
+        return _detail(f"{adapter.key} is not configured.", status.HTTP_409_CONFLICT)
+    if adapter.dispatch is None:
+        return _detail(f"{adapter.key} cannot be started by the administrator API.", status.HTTP_409_CONFLICT)
+    dispatch = adapter.dispatch(request)
+    return Response(dispatch.payload, status=dispatch.status_code)
 
 
 @api_view(["GET"])
 @permission_classes([IsAdmin])
 def integration_runs(request, key: str):
-    limit = min(max(int(request.query_params.get("limit", "10")), 1), 100)
-    records = DataSyncRun.objects.filter(source__icontains=key.lower()).order_by("-id")[:limit]
-    return Response([_integration_run_data(item) for item in records])
+    adapter = integration_registry.get(key)
+    if adapter is None:
+        return _detail("Unknown integration key.", status.HTTP_404_NOT_FOUND)
+    try:
+        limit = min(max(int(request.query_params.get("limit", "10")), 1), 100)
+    except ValueError:
+        return _detail("limit must be an integer between 1 and 100.")
+    return Response([serialize_run(item) for item in adapter.records(str(request_organization_id(request)))[:limit]])
 
 
 @api_view(["GET"])
 @permission_classes([IsAdmin])
 def integration_run(request, run_id: int):
-    item = get_object_or_404(DataSyncRun, id=run_id)
-    return Response(_integration_run_data(item))
+    item = get_object_or_404(DataSyncRun, id=run_id, organization_id=request_organization_id(request))
+    return Response(serialize_run(item))
 
 
 def _stale_cadastres(days: int = 30):

--- a/django_backend/api/tests.py
+++ b/django_backend/api/tests.py
@@ -446,6 +446,45 @@ class MainParityWorkflowTests(TestCase):
         self.assertEqual(response.data[0]["result"], {"cadastres": 1, "notices": 2})
 
 
+class IntegrationRegistryApiTests(TestCase):
+    def setUp(self):
+        self.organization = Organization.objects.create(slug="registry-org", name="Registry organization")
+        self.other_organization = Organization.objects.create(slug="registry-other", name="Other registry organization")
+        self.admin = User.objects.create_user("registry-admin", "Registry administrator", "very-secure-password", default_organization=self.organization)
+        Privilege.objects.create(user=self.admin, code=PrivilegeCode.ADMIN)
+        self.client = APIClient()
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {token_pair(self.admin)['actualToken']['token']}")
+
+    def test_registry_declares_operational_state_and_checkpoint_for_each_adapter(self):
+        DataSyncRun.objects.create(source="cadastre", status=DataSyncRun.Status.SUCCESS, cursor={"page": 2}, organization=self.organization)
+        response = self.client.get("/api/services/admin/integrations")
+        self.assertEqual(response.status_code, 200, response.data)
+        adapters = {item["key"]: item for item in response.data}
+        self.assertEqual(set(adapters), {"CADASTRE", "FORESTEK", "PARIMUS"})
+        self.assertEqual(adapters["CADASTRE"]["status"], DataSyncRun.Status.SUCCESS)
+        self.assertEqual(adapters["CADASTRE"]["checkpoint"], {"page": 2})
+        self.assertEqual(adapters["CADASTRE"]["health"], "OK")
+        self.assertIn("lastRun", adapters["PARIMUS"])
+
+    def test_registry_history_is_scoped_and_unknown_work_never_runs(self):
+        DataSyncRun.objects.create(source="cadastre", status=DataSyncRun.Status.SUCCESS, organization=self.organization)
+        DataSyncRun.objects.create(source="cadastre", status=DataSyncRun.Status.SUCCESS, organization=self.other_organization)
+        response = self.client.get("/api/services/admin/integrations/CADASTRE/runs")
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["source"], "cadastre")
+        unknown = self.client.post("/api/services/admin/integrations/UNKNOWN/runs", {}, format="json")
+        self.assertEqual(unknown.status_code, 404)
+
+    @override_settings(PARIMUS_API_URL="", PARIMUS_API_TOKEN="")
+    @patch("api.integrations.run_parimus_official_notice_import.delay")
+    def test_unconfigured_adapter_is_rejected_before_dispatch(self, delay):
+        response = self.client.post("/api/services/admin/integrations/PARIMUS/runs", {}, format="json")
+        self.assertEqual(response.status_code, 409, response.data)
+        self.assertIn("not configured", response.data["detail"])
+        delay.assert_not_called()
+
+
 class MembershipRoleAuthorizationTests(TestCase):
     """AUTH-03: roles must apply within the active membership, not globally."""
 


### PR DESCRIPTION
## Kokkuvõte

See muudatus asendab admin-integratsioonide API allikapõhise hargnemise deklaratiivse adapteriregistriga. Iga adapter deklareerib võtme, nimetuse, käivitusrežiimi, auditiallika, konfiguratsioonikontrolli, viimase töö, checkpoint’i ja health’i.

Cadastre’i ning Pärimuse käivitused suunatakse oma sobivasse dispatcher’isse. Ühekordne Foresteki import jääb admin-API kaudu blokeerituks. Tundmatu võti, seadistamata adapter ja vigane `limit` ei käivita tööd. Integratsioonide loend, tööde ajalugu ning individuaalne auditikirje on nüüd organisatsioonipõhiselt piiratud.

## Kontrollid

| Kontroll | Tulemus |
|---|---|
| `python3 -m py_compile api/integrations.py api/parity.py api/tests.py` | Läbis |
| `manage.py check` | Läbis |
| `makemigrations --check --dry-run` | Läbis |
| OpenAPI snapshoti genereerimine ja võrdlus | Läbis |
| Sihttestid SQLite’is | Ei ole käivitatavad olemasolevate GeoDjango/PostGIS migratsioonide tõttu; kohustuslik värav kasutab päris PostGIS-i |

Closes #42.
