### PR TITLE
feat(integrations): add Weasel ownership delta client

### DIFF
--- a/django_backend/api/integrations.py
+++ b/django_backend/api/integrations.py
@@ -8,7 +8,7 @@ from typing import Any
 from django.conf import settings
 
 from forestry.models import DataSyncRun
-from forestry.tasks import enqueue_cadastre_sync, enqueue_portfolio_sync, run_parimus_official_notice_import
+from forestry.tasks import enqueue_cadastre_sync, enqueue_portfolio_sync, run_parimus_official_notice_import, run_weasel_ownership_delta
 
 from .organization import request_organization_id
 from .serializers import json_value
@@ -125,6 +125,15 @@ def _parimus_dispatch(request) -> IntegrationDispatch:
     return IntegrationDispatch({"key": "PARIMUS", "status": "QUEUED", "taskId": task.id}, 202)
 
 
+def _weasel_dispatch(request) -> IntegrationDispatch:
+    organization_id = str(request_organization_id(request))
+    if settings.FORESTIQ_TASKS_INLINE:
+        result = run_weasel_ownership_delta.run(organization_id)
+        return IntegrationDispatch({"key": "WEASEL", "status": result.get("status", "SUCCESS"), "result": result}, 202)
+    task = run_weasel_ownership_delta.delay(organization_id)
+    return IntegrationDispatch({"key": "WEASEL", "status": "QUEUED", "taskId": task.id}, 202)
+
+
 def _forestek_dispatch(_request) -> IntegrationDispatch:
     return IntegrationDispatch(
         {"detail": "Forestek is a one-time initial import. Run the controlled management command only before its first successful import."},
@@ -152,5 +161,6 @@ integration_registry = IntegrationRegistry(
         IntegrationAdapter("CADASTRE", "Cadastre and forest registry", "RECURRING", "cadastre", lambda: True, _cadastre_dispatch),
         IntegrationAdapter("FORESTEK", "Forestek ownership relations", "ONE_TIME", "forestek", lambda: bool(settings.FORESTEK_API_URL and settings.FORESTEK_API_TOKEN), _forestek_dispatch),
         IntegrationAdapter("PARIMUS", "Pärimus official notices", "RECURRING", "parimus", lambda: bool(settings.PARIMUS_API_URL and settings.PARIMUS_API_TOKEN), _parimus_dispatch),
+        IntegrationAdapter("WEASEL", "Weasel ownership changes", "RECURRING", "weasel", lambda: bool(settings.WEASEL_API_URL and settings.WEASEL_API_TOKEN), _weasel_dispatch),
     )
 )

--- a/django_backend/api/tests.py
+++ b/django_backend/api/tests.py
@@ -460,7 +460,7 @@ class IntegrationRegistryApiTests(TestCase):
         response = self.client.get("/api/services/admin/integrations")
         self.assertEqual(response.status_code, 200, response.data)
         adapters = {item["key"]: item for item in response.data}
-        self.assertEqual(set(adapters), {"CADASTRE", "FORESTEK", "PARIMUS"})
+        self.assertEqual(set(adapters), {"CADASTRE", "FORESTEK", "PARIMUS", "WEASEL"})
         self.assertEqual(adapters["CADASTRE"]["status"], DataSyncRun.Status.SUCCESS)
         self.assertEqual(adapters["CADASTRE"]["checkpoint"], {"page": 2})
         self.assertEqual(adapters["CADASTRE"]["health"], "OK")

--- a/django_backend/config/settings.py
+++ b/django_backend/config/settings.py
@@ -229,6 +229,10 @@ CELERY_BEAT_SCHEDULE = {
         "task": "forestry.tasks.enqueue_all_organizations_parimus_official_notice_import",
         "schedule": float(os.getenv("FORESTIQ_PARIMUS_NOTICE_INTERVAL_SECONDS", "21600")),
     },
+    "forestiq-weasel-ownership-delta": {
+        "task": "forestry.tasks.enqueue_all_organizations_weasel_ownership_delta",
+        "schedule": float(os.getenv("FORESTIQ_WEASEL_DELTA_INTERVAL_SECONDS", "3600")),
+    },
 }
 FORESTIQ_TASKS_INLINE = env_bool("FORESTIQ_TASKS_INLINE", False)
 FORESTIQ_SYNC_HTTP_TIMEOUT_SECONDS = int(os.getenv("FORESTIQ_SYNC_HTTP_TIMEOUT_SECONDS", "30"))
@@ -287,6 +291,17 @@ FORESTEK_API_URL = os.getenv("FORESTEK_API_URL", "").rstrip("/")
 FORESTEK_API_TOKEN = os.getenv("FORESTEK_API_TOKEN", "")
 PARIMUS_API_URL = os.getenv("PARIMUS_API_URL", "").rstrip("/")
 PARIMUS_API_TOKEN = os.getenv("PARIMUS_API_TOKEN", "")
+# Weasel is a separate, opt-in ownership-change delta source. No endpoint or
+# credential is assumed until a production service contract is configured.
+WEASEL_API_URL = os.getenv("WEASEL_API_URL", "").rstrip("/")
+WEASEL_API_TOKEN = os.getenv("WEASEL_API_TOKEN", "")
+FORESTIQ_WEASEL_CHANGES_PATH = os.getenv("FORESTIQ_WEASEL_CHANGES_PATH", "/ownership-changes")
+FORESTIQ_WEASEL_DELTA_INTERVAL_SECONDS = int(os.getenv("FORESTIQ_WEASEL_DELTA_INTERVAL_SECONDS", "3600"))
+FORESTIQ_WEASEL_PAGE_SIZE = int(os.getenv("FORESTIQ_WEASEL_PAGE_SIZE", "100"))
+FORESTIQ_WEASEL_MAX_EVENTS = int(os.getenv("FORESTIQ_WEASEL_MAX_EVENTS", "1000"))
+FORESTIQ_WEASEL_MAX_PAYLOAD_BYTES = int(os.getenv("FORESTIQ_WEASEL_MAX_PAYLOAD_BYTES", "1048576"))
+FORESTIQ_WEASEL_MAX_RETRIES = int(os.getenv("FORESTIQ_WEASEL_MAX_RETRIES", "3"))
+FORESTIQ_WEASEL_RETRY_BACKOFF_SECONDS = float(os.getenv("FORESTIQ_WEASEL_RETRY_BACKOFF_SECONDS", "1"))
 
 LANGUAGE_CODE = "et-ee"
 TIME_ZONE = os.getenv("TIME_ZONE", "Europe/Tallinn")

--- a/django_backend/forestry/services/weasel_client.py
+++ b/django_backend/forestry/services/weasel_client.py
@@ -1,0 +1,125 @@
+"""Bounded client for Weasel ownership-change deltas."""
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+import json
+import time
+from typing import Any
+
+import requests
+from django.conf import settings
+
+
+class WeaselClientError(RuntimeError):
+    """The Weasel delta endpoint could not be safely consumed."""
+
+
+@dataclass(frozen=True)
+class WeaselPolicy:
+    page_size: int
+    max_events: int
+    max_payload_bytes: int
+    max_retries: int
+    retry_backoff_seconds: float
+
+    @classmethod
+    def from_settings(cls) -> "WeaselPolicy":
+        return cls(
+            page_size=settings.FORESTIQ_WEASEL_PAGE_SIZE,
+            max_events=settings.FORESTIQ_WEASEL_MAX_EVENTS,
+            max_payload_bytes=settings.FORESTIQ_WEASEL_MAX_PAYLOAD_BYTES,
+            max_retries=settings.FORESTIQ_WEASEL_MAX_RETRIES,
+            retry_backoff_seconds=settings.FORESTIQ_WEASEL_RETRY_BACKOFF_SECONDS,
+        )
+
+
+@dataclass(frozen=True)
+class WeaselChangePage:
+    events: list[dict[str, Any]]
+    next_cursor: str | None
+
+
+class WeaselOwnershipClient:
+    """Read cursor-based ownership-change pages with bounded network behavior."""
+
+    _RETRYABLE_STATUS_CODES = frozenset((429, 500, 502, 503, 504))
+
+    def __init__(
+        self,
+        policy: WeaselPolicy | None = None,
+        *,
+        request_get: Callable[..., requests.Response] = requests.get,
+        sleep: Callable[[float], None] = time.sleep,
+    ) -> None:
+        self.policy = policy or WeaselPolicy.from_settings()
+        self.request_get = request_get
+        self.sleep = sleep
+
+    def _url(self) -> str:
+        base_url = settings.WEASEL_API_URL.rstrip("/")
+        path = settings.FORESTIQ_WEASEL_CHANGES_PATH.strip()
+        if not base_url or not settings.WEASEL_API_TOKEN:
+            raise WeaselClientError("Weasel API URL and token must be configured before synchronization.")
+        if not path.startswith("/"):
+            path = f"/{path}"
+        return f"{base_url}{path}"
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Accept": "application/json",
+            "Authorization": f"Bearer {settings.WEASEL_API_TOKEN}",
+            "User-Agent": settings.FORESTIQ_SYNC_USER_AGENT,
+        }
+
+    def _payload_size(self, response: requests.Response, payload: dict[str, Any]) -> int:
+        content_length = str(getattr(response, "headers", {}).get("Content-Length", ""))
+        try:
+            declared_size = int(content_length)
+        except ValueError:
+            declared_size = 0
+        if declared_size > self.policy.max_payload_bytes:
+            raise WeaselClientError(f"Weasel response exceeds the {self.policy.max_payload_bytes}-byte payload policy.")
+        content = getattr(response, "content", None)
+        return len(content) if isinstance(content, (bytes, bytearray)) else len(json.dumps(payload, separators=(",", ":")).encode("utf-8"))
+
+    def ownership_change_page(self, cursor: str | None = None) -> WeaselChangePage:
+        if self.policy.page_size < 1 or self.policy.page_size > self.policy.max_events:
+            raise WeaselClientError("Weasel page size must be positive and not exceed the event budget.")
+        params: dict[str, Any] = {"limit": self.policy.page_size}
+        if cursor:
+            params["cursor"] = cursor
+        response: requests.Response | None = None
+        for attempt in range(self.policy.max_retries + 1):
+            try:
+                response = self.request_get(
+                    self._url(), params=params, headers=self._headers(), timeout=settings.FORESTIQ_SYNC_HTTP_TIMEOUT_SECONDS
+                )
+                if response.status_code in self._RETRYABLE_STATUS_CODES and attempt < self.policy.max_retries:
+                    self.sleep(self.policy.retry_backoff_seconds * (2**attempt))
+                    continue
+                response.raise_for_status()
+                break
+            except requests.RequestException as exc:
+                if attempt == self.policy.max_retries:
+                    raise WeaselClientError(f"Weasel request failed after {attempt + 1} attempt(s): {exc}") from exc
+                self.sleep(self.policy.retry_backoff_seconds * (2**attempt))
+        else:  # pragma: no cover - loop either raises or returns a response
+            raise WeaselClientError("Weasel request did not produce a response.")
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            raise WeaselClientError("Weasel returned non-JSON data.") from exc
+        if not isinstance(payload, dict):
+            raise WeaselClientError("Weasel returned an invalid delta page.")
+        if self._payload_size(response, payload) > self.policy.max_payload_bytes:
+            raise WeaselClientError(f"Weasel response exceeds the {self.policy.max_payload_bytes}-byte payload policy.")
+        events = payload.get("events", payload.get("items", []))
+        if not isinstance(events, list) or any(not isinstance(event, dict) for event in events):
+            raise WeaselClientError("Weasel delta page must contain an events array.")
+        if len(events) > self.policy.page_size:
+            raise WeaselClientError("Weasel delta page exceeds the requested limit.")
+        next_cursor = payload.get("nextCursor", payload.get("next_cursor"))
+        if next_cursor is not None and not isinstance(next_cursor, (str, int)):
+            raise WeaselClientError("Weasel next cursor must be text or numeric.")
+        return WeaselChangePage(events=events, next_cursor=str(next_cursor) if next_cursor not in (None, "") else None)

--- a/django_backend/forestry/services/weasel_ownership_sync.py
+++ b/django_backend/forestry/services/weasel_ownership_sync.py
@@ -1,0 +1,66 @@
+"""Import Weasel ownership-change pages into the tenant-scoped event projection."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from django.utils import timezone
+from django.utils.dateparse import parse_datetime
+
+from forestry.models import Cadastre, Owner
+from operations.models import OwnershipTransitionEvent
+
+from .weasel_client import WeaselOwnershipClient
+
+
+def _value(event: dict[str, Any], *names: str) -> str:
+    for name in names:
+        value = event.get(name)
+        if value not in (None, ""):
+            return str(value).strip()
+    return ""
+
+
+def _occurred_at(event: dict[str, Any]):
+    raw = _value(event, "occurredAt", "occurred_at", "timestamp", "date")
+    if not raw:
+        return None
+    parsed = parse_datetime(raw)
+    if parsed is None:
+        try:
+            parsed = datetime.fromisoformat(raw)
+        except ValueError:
+            return None
+    return timezone.make_aware(parsed, timezone.get_current_timezone()) if timezone.is_naive(parsed) else parsed
+
+
+def import_weasel_ownership_deltas(
+    *,
+    organization_id: str,
+    client: WeaselOwnershipClient | None = None,
+    cursor: str | None = None,
+) -> dict[str, object]:
+    """Fetch one bounded delta page and persist its events within one tenant only."""
+
+    page = (client or WeaselOwnershipClient()).ownership_change_page(cursor)
+    imported = 0
+    ignored = 0
+    for event in page.events:
+        owner_id = _value(event, "ownerId", "owner_id", "ownerCode", "owner_code")
+        cadastre_id = _value(event, "cadastreId", "cadastre_id", "cadastralCode", "cadastral_code")
+        owner = Owner.objects.filter(organization_id=organization_id, id=owner_id).first() if owner_id else None
+        cadastre = Cadastre.objects.filter(organization_id=organization_id, id=cadastre_id).first() if cadastre_id else None
+        if owner is None and cadastre is None:
+            ignored += 1
+            continue
+        OwnershipTransitionEvent.objects.create(
+            organization_id=organization_id,
+            owner=owner,
+            cadastre=cadastre,
+            event_type=_value(event, "eventType", "event_type", "type") or "OWNERSHIP_CHANGE",
+            occurred_at=_occurred_at(event),
+            source_reference=_value(event, "id", "eventId", "event_id", "reference"),
+            payload=event,
+        )
+        imported += 1
+    return {"events": imported, "ignored": ignored, "nextCursor": page.next_cursor}

--- a/django_backend/forestry/tasks.py
+++ b/django_backend/forestry/tasks.py
@@ -22,6 +22,8 @@ from forestry.services.external_sync import (
 )
 from forestry.services.metsaregister_full_import import import_metsaregister_delta
 from forestry.services.single_flight import SingleFlightLock
+from forestry.services.weasel_client import WeaselClientError
+from forestry.services.weasel_ownership_sync import import_weasel_ownership_deltas
 
 
 @dataclass(frozen=True)
@@ -369,9 +371,56 @@ def run_parimus_official_notice_import(self, organization_id: str) -> dict[str, 
 @shared_task
 def enqueue_all_organizations_parimus_official_notice_import() -> dict[str, int]:
     """Beat entry point for auditable Pärimus official-notice refreshes."""
-
     queued = 0
     for organization_id in Organization.objects.filter(is_active=True).values_list("id", flat=True):
         result = run_parimus_official_notice_import.delay(str(organization_id))
         queued += 1 if result else 0
     return {"organizations": queued}
+
+
+@shared_task(bind=True, autoretry_for=(ConnectionError, WeaselClientError), retry_backoff=True, max_retries=settings.FORESTIQ_SYNC_RUN_MAX_RETRIES)
+def run_weasel_ownership_delta(self, organization_id: str, cursor: str | None = None) -> dict[str, object]:
+    """Import one bounded Weasel ownership-change page for one organization."""
+
+    lock = SingleFlightLock.for_sync("weasel-ownership-delta", organization_id)
+    if not lock.acquire():
+        return {"status": "already_running"}
+    try:
+        with organization_scope(organization_id):
+            run = DataSyncRun.objects.create(
+                source="weasel:ownership-delta",
+                status=DataSyncRun.Status.RUNNING,
+                started_at=timezone.now(),
+                task_id=self.request.id or "",
+                correlation_id=current_correlation_id(),
+                cursor={"cursor": cursor} if cursor else {},
+            )
+            try:
+                report = import_weasel_ownership_deltas(organization_id=organization_id, cursor=cursor)
+            except Exception as exc:
+                _fail(run, exc, retry_count=self.request.retries)
+                raise
+            next_cursor = report.get("nextCursor")
+            return _succeed(
+                run,
+                report,
+                pages_processed=1,
+                rows_processed=int(report["events"]),
+                cursor={"cursor": next_cursor} if next_cursor else {},
+                retry_count=self.request.retries,
+            )
+    finally:
+        lock.release()
+
+
+@shared_task
+def enqueue_all_organizations_weasel_ownership_delta() -> dict[str, int | str]:
+    """Beat entry point for separately auditable, opt-in Weasel delta imports."""
+
+    if not settings.WEASEL_API_URL or not settings.WEASEL_API_TOKEN:
+        return {"organizations": 0, "status": "not_configured"}
+    queued = 0
+    for organization_id in Organization.objects.filter(is_active=True).values_list("id", flat=True):
+        result = run_weasel_ownership_delta.delay(str(organization_id))
+        queued += 1 if result else 0
+    return {"organizations": queued, "status": "queued"}

--- a/django_backend/forestry/tests.py
+++ b/django_backend/forestry/tests.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, Mock, patch
 
 import requests
 
+from django.conf import settings
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.test import SimpleTestCase, TestCase, override_settings
@@ -17,7 +18,7 @@ from accounts.organization_context import organization_scope
 from accounts.models import Organization, User
 from api.auth import token_pair
 from forestry.models import Cadastre, CadastreNotification, CadastreSubPart, DataSyncRun, ForestRegistryFeature, ImportCheckpoint, Owner, OwnerLog
-from operations.models import Deal, DealStage
+from operations.models import Deal, DealStage, OwnershipTransitionEvent
 from forestry.services import import_runner
 from forestry.services.external_sync import sync_cadastre_wfs, sync_parimus_inheritance, wfs_features
 from forestry.services.metsaregister_full_import import FullImportReport, import_all_metsaregister, import_metsaregister_delta
@@ -26,9 +27,12 @@ from forestry.tasks import (
     run_cadastre_sync,
     run_metsaregister_delta_check,
     run_parimus_official_notice_import,
+    enqueue_all_organizations_weasel_ownership_delta,
 )
 from forestry.services.single_flight import SingleFlightLock
 from forestry.services.wfs_client import WfsClient, WfsClientError, WfsClientPolicy
+from forestry.services.weasel_client import WeaselChangePage, WeaselOwnershipClient, WeaselPolicy
+from forestry.services.weasel_ownership_sync import import_weasel_ownership_deltas
 
 
 def authenticated_client(user: User) -> APIClient:
@@ -922,3 +926,66 @@ class ScheduledParimusNoticeImportTests(TestCase):
         schedule = settings.CELERY_BEAT_SCHEDULE["forestiq-parimus-official-notices"]
         self.assertEqual(schedule["task"], "forestry.tasks.enqueue_all_organizations_parimus_official_notice_import")
         self.assertGreater(schedule["schedule"], 0)
+
+
+class WeaselOwnershipClientTests(SimpleTestCase):
+    @override_settings(WEASEL_API_URL="https://weasel.example.test", WEASEL_API_TOKEN="weasel-test-token")
+    def test_client_uses_bounded_cursor_page_and_bearer_authentication(self):
+        response = Mock(status_code=200, headers={"Content-Length": "64"}, content=b'{"events": []}')
+        response.json.return_value = {"events": [{"id": "change-1"}], "nextCursor": "cursor-2"}
+        request_get = Mock(return_value=response)
+        client = WeaselOwnershipClient(WeaselPolicy(page_size=10, max_events=10, max_payload_bytes=1024, max_retries=1, retry_backoff_seconds=0), request_get=request_get)
+
+        page = client.ownership_change_page("cursor-1")
+
+        self.assertEqual(page, WeaselChangePage(events=[{"id": "change-1"}], next_cursor="cursor-2"))
+        request_get.assert_called_once_with(
+            "https://weasel.example.test/ownership-changes",
+            params={"limit": 10, "cursor": "cursor-1"},
+            headers={"Accept": "application/json", "Authorization": "Bearer weasel-test-token", "User-Agent": settings.FORESTIQ_SYNC_USER_AGENT},
+            timeout=settings.FORESTIQ_SYNC_HTTP_TIMEOUT_SECONDS,
+        )
+
+    @override_settings(WEASEL_API_URL="https://weasel.example.test", WEASEL_API_TOKEN="weasel-test-token")
+    def test_client_retries_transient_response_before_success(self):
+        retry = Mock(status_code=503, headers={}, content=b"")
+        success = Mock(status_code=200, headers={}, content=b"{}")
+        success.json.return_value = {"events": []}
+        request_get = Mock(side_effect=[retry, success])
+        sleep = Mock()
+        client = WeaselOwnershipClient(WeaselPolicy(page_size=10, max_events=10, max_payload_bytes=1024, max_retries=1, retry_backoff_seconds=2), request_get=request_get, sleep=sleep)
+
+        self.assertEqual(client.ownership_change_page().events, [])
+        self.assertEqual(request_get.call_count, 2)
+        sleep.assert_called_once_with(2)
+
+
+class WeaselOwnershipImportTests(TestCase):
+    def setUp(self):
+        self.organization = Organization.objects.create(slug="weasel-org", name="Weasel organization")
+        self.other_organization = Organization.objects.create(slug="weasel-other", name="Other Weasel organization")
+        self.owner = Owner.objects.create(id="10101:001:0001", name="Weasel owner", organization=self.organization)
+        self.cadastre = Cadastre.objects.create(id="10101:001:0002", name="Weasel cadastre", organization=self.organization)
+        Owner.objects.create(id="20202:001:0001", name="Other owner", organization=self.other_organization)
+
+    def test_import_persists_only_events_linked_to_the_active_organization(self):
+        client = Mock()
+        client.ownership_change_page.return_value = WeaselChangePage(
+            events=[
+                {"id": "weasel-1", "eventType": "OWNER_CHANGED", "ownerId": self.owner.id, "cadastreId": self.cadastre.id, "occurredAt": "2026-08-28T09:00:00+03:00"},
+                {"id": "weasel-outside", "ownerId": "20202:001:0001", "eventType": "OWNER_CHANGED"},
+            ],
+            next_cursor="next-1",
+        )
+
+        report = import_weasel_ownership_deltas(organization_id=str(self.organization.id), client=client, cursor="current")
+
+        self.assertEqual(report, {"events": 1, "ignored": 1, "nextCursor": "next-1"})
+        event = OwnershipTransitionEvent.objects.get(source_reference="weasel-1")
+        self.assertEqual(event.organization_id, self.organization.id)
+        self.assertEqual(event.owner_id, self.owner.id)
+        self.assertEqual(event.cadastre_id, self.cadastre.id)
+
+    @override_settings(WEASEL_API_URL="", WEASEL_API_TOKEN="")
+    def test_unconfigured_scheduled_delta_does_not_enqueue_work(self):
+        self.assertEqual(enqueue_all_organizations_weasel_ownership_delta.run(), {"organizations": 0, "status": "not_configured"})


### PR DESCRIPTION
## Kokkuvõte

See muudatus lisab Forestekist sõltumatu, opt-in Weaseli omandimuutuste deltaimpordi. Kliendil on seadistatav URL, Bearer-token, muudatuste tee, timeout, page size, sündmuse- ja payload-eelarve ning retry/backoff. Iga päring kasutab cursor’it ning impordib ainult aktiivse organisatsiooni omaniku või katastriga seotud sündmused auditeeritavasse `OwnershipTransitionEvent` projektsiooni.

Weasel on lisatud üldisesse integratsiooniregistrisse, mistõttu administraator näeb selle konfiguratsiooni- ja health-seisu ning saab seadistatud allika käivitada sama admin-API kaudu. Perioodiline Celery töö on organisatsioonipõhine ja jätab seadistamata allika turvaliselt käivitamata. Foresteki ühekordne import jääb eraldi ning muutmata.

## Kontrollid

| Kontroll | Tulemus |
|---|---|
| `WeaselOwnershipClientTests` | Läbis, 2 testi |
| `manage.py check` | Läbis |
| `py_compile` | Läbis |
| `makemigrations --check --dry-run` | Läbis |
| Sündmusepüsivuse ja taski testid SQLite’is | Vajavad olemasolevate GeoDjango/PostGIS migratsioonide tõttu päris PostGIS-i; käivituvad kohustuslikus kvaliteediväravas |

Closes #39.
