### PR TITLE
feat(contracts): add contract management workspace

### DIFF
--- a/django_backend/api/parity.py
+++ b/django_backend/api/parity.py
@@ -957,7 +957,7 @@ def _deal_contract_draft(deal: Deal) -> dict:
     parcels = [{"cadastralCode": parcel.id, "address": parcel.address, "areaHectares": json_value(parcel.area)} for parcel in deal.parcels.all()]
     if not parcels:
         raise ValueError("The deal has no parcels to include in a contract.")
-    return {"dealId": str(deal.id), "offerEntryId": str(accepted_offer.id), "acceptedPrice": json_value(accepted_offer.amount), "acceptedTerms": accepted_offer.terms, "seller": {"name": deal.owner.name, "code": deal.owner.id, "address": deal.owner.address, "iban": ""}, "parcels": parcels}
+    return {"dealId": str(deal.id), "dealVersion": deal.version, "offerEntryId": str(accepted_offer.id), "acceptedPrice": json_value(accepted_offer.amount), "acceptedTerms": accepted_offer.terms, "seller": {"name": deal.owner.name, "code": deal.owner.id, "address": deal.owner.address, "iban": ""}, "parcels": parcels}
 
 
 @api_view(["GET"])

--- a/django_backend/api/tests.py
+++ b/django_backend/api/tests.py
@@ -415,6 +415,7 @@ class MainParityWorkflowTests(TestCase):
         self.assertEqual(Deal.objects.get(id=deal_id).offers.get(id=offer_id).status, DealOffer.Status.ACCEPTED)
         draft = self.client.get(f"/api/services/contracts/deals/{deal_id}/draft")
         self.assertEqual(draft.status_code, 200, draft.data)
+        self.assertEqual(draft.data["dealVersion"], won.data["version"])
         company = CompanyProfile.objects.create(organization=self.admin.default_organization, legal_name="ForestIQ ÕÄÖÜ OÜ")
         template = ContractTemplate.objects.create(
             organization=self.admin.default_organization,

--- a/forestiq-ui/client/src/App.tsx
+++ b/forestiq-ui/client/src/App.tsx
@@ -11,6 +11,7 @@ import { hasAccess, type AccessRequirement } from "@/lib/authorization";
 import { AccessDenied, AuthenticationRequired } from "@/pages/AccessState";
 import Admin from "@/pages/Admin";
 import Dashboard from "@/pages/Dashboard";
+import Contracts from "@/pages/Contracts";
 import Login from "@/pages/Login";
 import Management from "@/pages/Management";
 import InheritanceDetail from "@/pages/InheritanceDetail";
@@ -190,8 +191,8 @@ function Routes() {
         </Protected>
       </Route>
       <Route path="/contracts">
-        <Protected requirement={requirePrivileges("ADMIN", "OWNER_PROFILE")}>
-          <GenericWorkspace kind="contracts" />
+        <Protected requirement={requirePrivileges("ADMIN")}>
+          <Contracts />
         </Protected>
       </Route>
       <Route path="/phones">

--- a/forestiq-ui/client/src/components/OwnerWorkflowPanel.tsx
+++ b/forestiq-ui/client/src/components/OwnerWorkflowPanel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { BadgeEuro, FileText, Gavel, Plus, RefreshCw, ShieldCheck } from "lucide-react";
+import { Link } from "wouter";
 
 import { api } from "@/lib/api";
 import type { Deal, InheritanceCase, Owner } from "@/lib/types";
@@ -57,15 +58,6 @@ export function OwnerWorkflowPanel({ owner }: { owner: Owner }) {
     } catch (err) { setError(err instanceof Error ? err.message : "Pakkumise saatmine ebaõnnestus."); }
   };
 
-  const createContract = async (deal: Deal) => {
-    try {
-      const number = `FIQ-${new Date().getFullYear()}-${deal.id.slice(0, 8).toUpperCase()}`;
-      const created = await api.post<{ contractId: string }>("/services/contracts/generate-from-deal", { dealId: deal.id, version: deal.version, contractNumber: number, buyer: "ForestIQ buyer" });
-      setError(`Lepingu ${created.contractId} draft on loodud. Lisa PDF lepingute registris.`);
-      void refresh();
-    } catch (err) { setError(err instanceof Error ? err.message : "Lepingu drafti loomine ebaõnnestus."); }
-  };
-
   const checkNotice = async () => {
     try { await api.post(`/services/inheritance/owners/${owner.id}/official-notices/check`, {}); void refresh(); }
     catch (err) { setError(err instanceof Error ? err.message : "Pärimisteadet ei saanud kontrollida."); }
@@ -90,7 +82,7 @@ export function OwnerWorkflowPanel({ owner }: { owner: Owner }) {
           <strong>{deal.stage.replaceAll("_", " ")}</strong><p>{deal.saleSubject} · {deal.parcels.length} kinnistut · {deal.offers.length} pakkumist</p>
           {deal.stage === "EVALUATION" && <div className="mt-3 flex gap-2"><input aria-label="Hindamise pakkumishind" className="min-w-0 rounded-md border bg-background px-2 py-1" inputMode="decimal" value={evaluationAmount} onChange={(event) => setEvaluationAmount(event.target.value)} placeholder="Hind EUR" /><button className="secondary-action" onClick={() => void approveEvaluation(deal)}>Kinnita hindamine</button></div>}
           {deal.stage === "NEGOTIATION" && <div className="mt-3 flex gap-2"><input aria-label="Pakkumise summa" className="min-w-0 rounded-md border bg-background px-2 py-1" inputMode="decimal" value={offerAmount} onChange={(event) => setOfferAmount(event.target.value)} placeholder="EUR" /><button className="secondary-action" onClick={() => void sendOffer(deal)}>Saada pakkumine</button></div>}
-          {deal.stage === "WON" && <button className="secondary-action mt-3" onClick={() => void createContract(deal)}><FileText size={16} /> Koosta lepingu draft</button>}
+          {deal.stage === "WON" && <Link className="secondary-action mt-3" href={`/contracts?dealId=${encodeURIComponent(deal.id)}`}><FileText size={16} /> Koosta leping</Link>}
         </div>)}
         {!deals.length && <p className="text-sm text-muted-foreground">Aktiivseid tehinguid ei ole.</p>}
       </div>

--- a/forestiq-ui/client/src/index.css
+++ b/forestiq-ui/client/src/index.css
@@ -15,3 +15,41 @@
 
 /* EXT-02: ownership-transition audit evidence */
 .ownership-audit-panel{margin-top:18px}.ownership-audit-panel .panel-heading>svg{color:var(--moss)}.ownership-audit-list{padding:3px 20px 12px}.ownership-audit-row{display:flex;align-items:center;justify-content:space-between;gap:20px;padding:13px 3px;border-top:1px solid #edf0ea}.ownership-audit-row:first-child{border-top:0}.ownership-audit-row strong,.ownership-audit-row small,.ownership-audit-row span{display:block}.ownership-audit-row strong{font-size:12px;text-transform:capitalize}.ownership-audit-row small{font-size:10px;color:var(--muted);margin-top:4px}.ownership-audit-row>div:last-child{text-align:right}.ownership-audit-row span{font-size:10px;color:var(--moss);font-weight:800;word-break:break-all}@media(max-width:760px){.ownership-audit-list{padding:3px 16px 10px}.ownership-audit-row{align-items:flex-start;flex-direction:column;gap:4px;padding:12px 3px}.ownership-audit-row>div:last-child{text-align:left}}
+
+/* CON-06 contract workspace */
+.contracts-intro { align-items: center; }
+.contracts-tabs { display: flex; flex-wrap: wrap; gap: .5rem; margin: 1.25rem 0; border-bottom: 1px solid var(--line); padding-bottom: .75rem; }
+.contracts-tabs button { border-radius: .5rem; border: 1px solid transparent; background: transparent; padding: .55rem .8rem; font-size: .875rem; font-weight: 700; color: var(--muted); }
+.contracts-tabs button.active { border-color: var(--spruce); background: var(--spruce); color: white; }
+.contracts-panel { overflow: hidden; }
+.contracts-filters { align-items: end; flex-wrap: wrap; gap: .75rem; }
+.contracts-filters label, .contract-field { display: grid; gap: .35rem; color: var(--muted); font-size: .75rem; font-weight: 700; }
+.contracts-filters label:first-child { display: flex; min-width: 15rem; align-items: center; gap: .5rem; border: 1px solid var(--line); border-radius: .5rem; padding: 0 .65rem; }
+.contracts-filters input, .contracts-filters select, .contract-field input, .contract-field select, .contract-form input, .contract-form select, .contract-form textarea, .contract-inline-form input { min-height: 2.35rem; border: 1px solid var(--line); border-radius: .45rem; background: white; padding: .45rem .6rem; color: var(--ink); }
+.contracts-filters label:first-child input { width: 100%; border: 0; background: transparent; padding-left: 0; }
+.contracts-filters label:first-child input:focus { outline: 0; }
+.contract-actions { display: flex; flex-wrap: wrap; gap: .4rem; }
+.contract-actions .secondary-action { margin: 0; padding: .35rem .55rem; font-size: .75rem; }
+.contracts-grid { display: grid; gap: 1rem; grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.contracts-preview { grid-column: 1 / -1; }
+.contracts-preview iframe { width: 100%; min-height: 32rem; border: 1px solid var(--line); border-radius: .5rem; background: white; }
+.contract-inline-form { display: flex; gap: .5rem; }
+.contract-inline-form input { min-width: 0; flex: 1; }
+.contract-inline-form .secondary-action { margin: 0; }
+.contract-draft { margin-top: 1rem; border-left: 3px solid var(--spruce); border-radius: .25rem; background: #eff4e9; padding: .75rem; font-size: .875rem; }
+.contract-draft p { margin: .3rem 0 0; color: var(--muted); }
+.contract-field { margin-top: 1rem; }
+.contract-form { display: grid; gap: .65rem; }
+.contract-form textarea { resize: vertical; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+.contract-list { display: grid; gap: .45rem; margin-top: 1.25rem; }
+.contract-list > div { display: flex; justify-content: space-between; gap: .75rem; border-top: 1px solid var(--line); padding-top: .55rem; font-size: .875rem; }
+.contract-list span { color: var(--muted); text-align: right; }
+.contract-modal-backdrop { position: fixed; z-index: 50; inset: 0; display: grid; place-items: center; overflow-y: auto; background: rgb(9 42 34 / .55); padding: 1rem; }
+.contract-modal { width: min(42rem, 100%); max-height: calc(100vh - 2rem); overflow: auto; padding: 1.25rem; }
+.contract-modal dl { display: grid; grid-template-columns: 10rem 1fr; gap: .65rem 1rem; margin-top: 1rem; font-size: .9rem; }
+.contract-modal dt { color: var(--muted); font-weight: 700; }
+.contract-modal dd { margin: 0; }
+.contract-modal pre { max-height: 15rem; overflow: auto; margin-top: .75rem; border-radius: .5rem; background: #eff4e9; padding: .75rem; font-size: .75rem; }
+.success-notice { margin: 1rem 0; border: 1px solid #78a46a; border-radius: .5rem; background: #edf6e9; padding: .75rem 1rem; color: #245b30; }
+@media (max-width: 800px) { .contracts-grid { grid-template-columns: 1fr; } .contracts-filters label:first-child { width: 100%; } .data-table .table-row { grid-template-columns: minmax(8rem, 1fr) minmax(7rem, 1fr); } .data-table .table-row > :nth-child(n+3) { margin-top: .35rem; } .contract-modal dl { grid-template-columns: 1fr; gap: .2rem; } .contract-modal dd { margin-bottom: .65rem; } }
+.contract-form-actions{display:flex;gap:.6rem;align-items:center}.contract-form-actions .primary-action{flex:1}.contract-form-actions .secondary-action{margin:0}.contract-list>div>div:first-child{display:grid;gap:.2rem}.contract-list-actions{display:flex;align-items:center;gap:.45rem}.contract-list-actions button{background:transparent;color:var(--moss);font-size:.75rem;font-weight:800;padding:.2rem}.contract-list-actions button:last-child{color:#984d42}

--- a/forestiq-ui/client/src/lib/api.ts
+++ b/forestiq-ui/client/src/lib/api.ts
@@ -109,7 +109,22 @@ export const api = {
   patch: <T>(path: string, body: unknown) => jsonRequest<T>("PATCH", path, body),
   upload: <T>(path: string, body: FormData, method: "POST" | "PUT" = "POST") =>
     fetch(`${BASE_URL}${path}`, { method, headers: headers(), body }).then(parse<T>),
-  delete: <T>(path: string) => fetch(`${BASE_URL}${path}`, { method: "DELETE", headers: headers() }).then(parse<T>),
+  delete: <T>(path: string, body?: unknown) => fetch(`${BASE_URL}${path}`, { method: "DELETE", headers: headers(body !== undefined), body: body === undefined ? undefined : JSON.stringify(body) }).then(parse<T>),
+  async download(path: string, filename: string): Promise<void> {
+    const response = await fetch(`${BASE_URL}${path}`, { headers: headers() });
+    if (!response.ok) {
+      const data = await response.json().catch(() => null);
+      throw new ApiError(data?.detail || `Allalaadimine ebaõnnestus (${response.status})`, response.status);
+    }
+    const url = URL.createObjectURL(await response.blob());
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = filename;
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+    URL.revokeObjectURL(url);
+  },
 
   async oidcConfiguration(): Promise<OidcConfiguration> {
     return parse<OidcConfiguration>(await fetch(`${BASE_URL}/oidc/config`));

--- a/forestiq-ui/client/src/lib/authorization.test.ts
+++ b/forestiq-ui/client/src/lib/authorization.test.ts
@@ -17,6 +17,8 @@ describe("route authorization", () => {
     expect(hasAccess(viewer, requirementForPath("/inheritance/case-123"))).toBe(false);
     expect(hasAccess(admin, requirementForPath("/management"))).toBe(true);
     expect(hasAccess(caller, requirementForPath("/management"))).toBe(false);
+    expect(hasAccess(admin, requirementForPath("/contracts"))).toBe(true);
+    expect(hasAccess(caller, requirementForPath("/contracts"))).toBe(false);
   });
 
   it("exposes navigation entries only to roles with the required privileges", () => {
@@ -30,7 +32,9 @@ describe("route authorization", () => {
     expect(adminLinks).toContain("/integrations");
     expect(adminLinks).toContain("/admin");
     expect(adminLinks).toContain("/management");
+    expect(adminLinks).toContain("/contracts");
     expect(callerLinks).not.toContain("/management");
+    expect(callerLinks).not.toContain("/contracts");
   });
 
   it("does not treat an unrelated route as privileged", () => {

--- a/forestiq-ui/client/src/lib/authorization.ts
+++ b/forestiq-ui/client/src/lib/authorization.ts
@@ -26,7 +26,7 @@ export const routeAccess: Record<string, AccessRequirement | undefined> = {
   "/workdesk/evaluator": withPrivilege("ADMIN", "EVALUATION"),
   "/workdesk/admin": withPrivilege("ADMIN"),
   "/admin": withPrivilege("ADMIN"),
-  "/contracts": withPrivilege("ADMIN", "OWNER_PROFILE"),
+  "/contracts": withPrivilege("ADMIN"),
   "/phones": withPrivilege("ADMIN", "PHONES"),
 };
 

--- a/forestiq-ui/client/src/lib/types.ts
+++ b/forestiq-ui/client/src/lib/types.ts
@@ -181,3 +181,65 @@ export interface SyncRun {
   result: Record<string, unknown>;
   error: string | null;
 }
+
+export interface ContractHistoryRecord {
+  id: string;
+  version: number | null;
+  sellers: string;
+  buyer: string;
+  contractNo: string;
+  created: number | string | null;
+  status: "ACTIVE" | "ARCHIVED" | "ORPHANED";
+  dealId?: string | null;
+  ownerId?: string | null;
+  retentionUntil?: number | string | null;
+  templateVersion?: ContractTemplateSnapshot | null;
+}
+
+export interface CompanyProfile {
+  id: string;
+  legalName: string;
+  registryCode?: string | null;
+  vatNumber?: string | null;
+  address?: string | null;
+  email?: string | null;
+  phone?: string | null;
+  iban?: string | null;
+  signatoryName?: string | null;
+  website?: string | null;
+  version: number;
+  createdAt?: number | string | null;
+  updatedAt?: number | string | null;
+}
+
+export interface ContractTemplate {
+  id: string;
+  companyProfileId?: string | null;
+  templateKey: string;
+  name: string;
+  description?: string | null;
+  html: string;
+  version: number;
+  isActive: boolean;
+  supersedesId?: string | null;
+  createdAt?: number | string | null;
+}
+
+export interface ContractTemplateSnapshot {
+  templateId: string;
+  templateKey: string;
+  version: number;
+  name: string;
+  html: string;
+  companyProfile?: CompanyProfile | null;
+}
+
+export interface ContractDraft {
+  dealId: string;
+  dealVersion: number;
+  offerEntryId: string;
+  acceptedPrice?: number | null;
+  acceptedTerms?: string | null;
+  seller: { name: string; code: string; address?: string | null; iban?: string | null };
+  parcels: { cadastralCode: string; address?: string | null; areaHectares?: number | null }[];
+}

--- a/forestiq-ui/client/src/pages/Contracts.tsx
+++ b/forestiq-ui/client/src/pages/Contracts.tsx
@@ -1,0 +1,181 @@
+import { FormEvent, useCallback, useEffect, useMemo, useState } from "react";
+import { Download, Eye, FilePlus2, FileStack, Plus, Search, Settings2 } from "lucide-react";
+import { Link, useLocation } from "wouter";
+
+import { AppShell } from "@/components/AppShell";
+import { api } from "@/lib/api";
+import type { CompanyProfile, ContractDraft, ContractHistoryRecord, ContractTemplate } from "@/lib/types";
+
+type Tab = "history" | "create" | "settings";
+type TemplateForm = { templateKey: string; name: string; description: string; html: string; companyProfileId: string };
+type ProfileForm = { legalName: string; registryCode: string; address: string; email: string; phone: string; iban: string; signatoryName: string; website: string };
+
+const blankTemplate: TemplateForm = { templateKey: "", name: "", description: "", html: "<h1>Ostu-müügileping</h1>\n<p>{{company.legalName}}</p>\n<p>{{deal.sellerName}}</p>", companyProfileId: "" };
+const blankProfile: ProfileForm = { legalName: "", registryCode: "", address: "", email: "", phone: "", iban: "", signatoryName: "", website: "" };
+
+function apiError(error: unknown, fallback: string) { return error instanceof Error ? error.message : fallback; }
+function formatDate(value?: number | string | null) { if (!value) return "—"; const date = new Date(typeof value === "number" && value < 1_000_000_000_000 ? value * 1000 : value); return Number.isNaN(date.valueOf()) ? "—" : new Intl.DateTimeFormat("et-EE", { dateStyle: "medium", timeStyle: "short" }).format(date); }
+function inputDate(value?: string | number | null) { if (!value) return ""; const date = new Date(typeof value === "number" && value < 1_000_000_000_000 ? value * 1000 : value); return Number.isNaN(date.valueOf()) ? "" : date.toISOString().slice(0, 10); }
+
+export default function Contracts() {
+  const [, navigate] = useLocation();
+  const initialDealId = new URLSearchParams(window.location.search).get("dealId") || "";
+  const [tab, setTab] = useState<Tab>(initialDealId ? "create" : "history");
+  const [contracts, setContracts] = useState<ContractHistoryRecord[]>([]);
+  const [templates, setTemplates] = useState<ContractTemplate[]>([]);
+  const [profiles, setProfiles] = useState<CompanyProfile[]>([]);
+  const [query, setQuery] = useState("");
+  const [status, setStatus] = useState("ALL");
+  const [fromDate, setFromDate] = useState("");
+  const [toDate, setToDate] = useState("");
+  const [selected, setSelected] = useState<ContractHistoryRecord | null>(null);
+  const [detail, setDetail] = useState<Record<string, unknown> | null>(null);
+  const [dealId, setDealId] = useState(initialDealId);
+  const [draft, setDraft] = useState<ContractDraft | null>(null);
+  const [templateId, setTemplateId] = useState("");
+  const [contractNumber, setContractNumber] = useState("");
+  const [previewHtml, setPreviewHtml] = useState("");
+  const [templateForm, setTemplateForm] = useState<TemplateForm>(blankTemplate);
+  const [profileForm, setProfileForm] = useState<ProfileForm>(blankProfile);
+  const [editingTemplate, setEditingTemplate] = useState<ContractTemplate | null>(null);
+  const [editingProfile, setEditingProfile] = useState<CompanyProfile | null>(null);
+  const [notice, setNotice] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(true);
+
+  const refresh = useCallback(async () => {
+    setLoading(true); setError("");
+    try {
+      const parameters = new URLSearchParams();
+      if (status !== "ALL") parameters.set("status", status);
+      if (fromDate) parameters.set("from", fromDate);
+      if (toDate) parameters.set("to", toDate);
+      const suffix = parameters.toString() ? `?${parameters}` : "";
+      const [history, activeTemplates, companyProfiles] = await Promise.all([
+        api.get<ContractHistoryRecord[]>(`/services/contracts${suffix}`),
+        api.get<ContractTemplate[]>("/services/contract-templates"),
+        api.get<CompanyProfile[]>("/services/company-profiles"),
+      ]);
+      setContracts(history); setTemplates(activeTemplates); setProfiles(companyProfiles);
+      const firstActiveTemplate = activeTemplates.find((template) => template.isActive);
+      if (!templateId && firstActiveTemplate) setTemplateId(firstActiveTemplate.id);
+    } catch (reason) { setError(apiError(reason, "Lepingute andmeid ei saanud laadida.")); }
+    finally { setLoading(false); }
+  }, [fromDate, status, templateId, toDate]);
+
+  useEffect(() => { void refresh(); }, [refresh]);
+
+  const filteredContracts = useMemo(() => {
+    const normalized = query.trim().toLocaleLowerCase("et-EE");
+    if (!normalized) return contracts;
+    return contracts.filter((contract) => [contract.contractNo, contract.sellers, contract.buyer, contract.ownerId, contract.dealId, contract.status].filter(Boolean).join(" ").toLocaleLowerCase("et-EE").includes(normalized));
+  }, [contracts, query]);
+  const activeTemplates = templates.filter((template) => template.isActive);
+  const chosenTemplate = activeTemplates.find((template) => template.id === templateId) || null;
+  const chosenProfile = profiles.find((profile) => profile.id === chosenTemplate?.companyProfileId) || null;
+
+  const loadDraft = async () => {
+    if (!dealId.trim()) { setError("Sisesta tehingu tunnus või ava lepingu koostamine tehingu töökaardilt."); return; }
+    try {
+      setError("");
+      const nextDraft = await api.get<ContractDraft>(`/services/contracts/deals/${encodeURIComponent(dealId.trim())}/draft`);
+      setDraft(nextDraft);
+      setContractNumber(`FIQ-${new Date().getFullYear()}-${nextDraft.dealId.slice(0, 8).toUpperCase()}`);
+      setPreviewHtml("");
+    } catch (reason) { setDraft(null); setError(apiError(reason, "Lepingu lähteandmeid ei saanud laadida.")); }
+  };
+
+  const preview = async () => {
+    if (!draft || !chosenTemplate) { setError("Vali sobiv tehing ja aktiivne lepingumall."); return; }
+    try {
+      setError("");
+      const result = await api.post<{ html: string }>(`/services/contract-templates/${chosenTemplate.id}/preview`, { dealId: draft.dealId });
+      setPreviewHtml(result.html);
+    } catch (reason) { setError(apiError(reason, "Malli eelvaadet ei saanud koostada.")); }
+  };
+
+  const generate = async () => {
+    if (!draft || !chosenTemplate || !contractNumber.trim()) { setError("Sisesta lepingu number ning vali tehing ja aktiivne mall."); return; }
+    try {
+      setError("");
+      const result = await api.post<{ contractId: string; pdf: string }>("/services/contracts/generate-from-deal", { dealId: draft.dealId, version: draft.dealVersion, contractNumber: contractNumber.trim(), templateId: chosenTemplate.id, buyer: chosenProfile?.legalName || "ForestIQ buyer" });
+      setNotice(`Leping ${result.contractId} loodi serveripoolse PDF-iga.`);
+      await refresh();
+      navigate(`/contracts?contractId=${encodeURIComponent(result.contractId)}`);
+      setTab("history");
+    } catch (reason) { setError(apiError(reason, "Lepingut ei saanud genereerida.")); }
+  };
+
+  const openDetail = async (contract: ContractHistoryRecord) => {
+    setSelected(contract); setDetail(null); setError("");
+    try { setDetail(await api.get<Record<string, unknown>>(`/services/contracts/${encodeURIComponent(contract.id)}`)); }
+    catch (reason) { setError(apiError(reason, "Lepingu detaili ei saanud laadida.")); }
+  };
+
+  const archive = async (contract: ContractHistoryRecord) => {
+    if (contract.version == null) { setError("Orvuks jäänud lepingut ei saa kasutajaliidesest arhiveerida."); return; }
+    try { await api.patch(`/services/contracts/${encodeURIComponent(contract.id)}`, { status: "ARCHIVED", version: contract.version }); setNotice(`Leping ${contract.contractNo} arhiveeriti.`); setSelected(null); await refresh(); }
+    catch (reason) { setError(apiError(reason, "Lepingut ei saanud arhiveerida.")); }
+  };
+
+  const createProfile = async (event: FormEvent) => {
+    event.preventDefault();
+    try {
+      if (editingProfile) await api.patch<CompanyProfile>(`/services/company-profiles/${editingProfile.id}`, { ...profileForm, version: editingProfile.version });
+      else await api.post<CompanyProfile>("/services/company-profiles", profileForm);
+      setProfileForm(blankProfile); setEditingProfile(null); setNotice(editingProfile ? "Ettevõtteprofiil uuendati." : "Ettevõtteprofiil lisati."); await refresh();
+    } catch (reason) { setError(apiError(reason, "Ettevõtteprofiili ei saanud salvestada.")); }
+  };
+
+  const createTemplate = async (event: FormEvent) => {
+    event.preventDefault();
+    try {
+      const payload = { ...templateForm, companyProfileId: templateForm.companyProfileId || null };
+      if (editingTemplate) await api.patch<ContractTemplate>(`/services/contract-templates/${editingTemplate.id}`, { ...payload, version: editingTemplate.version });
+      else await api.post<ContractTemplate>("/services/contract-templates", payload);
+      setTemplateForm(blankTemplate); setEditingTemplate(null); setNotice(editingTemplate ? "Lepingumallil loodi uus versioon." : "Lepingumall lisati."); await refresh();
+    } catch (reason) { setError(apiError(reason, "Lepingumalli ei saanud salvestada.")); }
+  };
+
+  const beginProfileEdit = (profile: CompanyProfile) => {
+    setEditingProfile(profile);
+    setProfileForm({ legalName: profile.legalName, registryCode: profile.registryCode || "", address: profile.address || "", email: profile.email || "", phone: profile.phone || "", iban: profile.iban || "", signatoryName: profile.signatoryName || "", website: profile.website || "" });
+  };
+  const beginTemplateEdit = (template: ContractTemplate) => {
+    setEditingTemplate(template);
+    setTemplateForm({ templateKey: template.templateKey, name: template.name, description: template.description || "", html: template.html, companyProfileId: template.companyProfileId || "" });
+  };
+  const archiveTemplate = async (template: ContractTemplate) => {
+    try { await api.delete<ContractTemplate>(`/services/contract-templates/${template.id}`, { version: template.version }); setNotice(`Mall ${template.name} arhiveeriti.`); await refresh(); }
+    catch (reason) { setError(apiError(reason, "Lepingumalli ei saanud arhiveerida.")); }
+  };
+  const deleteProfile = async (profile: CompanyProfile) => {
+    try { await api.delete(`/services/company-profiles/${profile.id}`); setNotice(`Ettevõtteprofiil ${profile.legalName} kustutati.`); await refresh(); }
+    catch (reason) { setError(apiError(reason, "Ettevõtteprofiili ei saanud kustutada.")); }
+  };
+
+  return <AppShell title="Lepingute tööala" eyebrow="KOMMERTS / LEPINGUD">
+    <section className="workspace-intro contracts-intro"><FileStack size={24} /><div><h2>Lepingud, eelvaated ja mallid ühel tööpinnal</h2><p>Otsi ning laadi alla lepinguid, koosta võidetud tehingust mallipõhine PDF ja halda ettevõtteprofiile.</p></div><div className="workspace-count">{contracts.length}<small>lepingut</small></div></section>
+    {notice && <div className="success-notice">{notice}</div>}{error && <div className="connection-warning">{error}</div>}
+    <div className="contracts-tabs" role="tablist" aria-label="Lepingute tööala vaated">
+      <button className={tab === "history" ? "active" : ""} onClick={() => setTab("history")} role="tab" aria-selected={tab === "history"}>Lepingute register</button>
+      <button className={tab === "create" ? "active" : ""} onClick={() => setTab("create")} role="tab" aria-selected={tab === "create"}>Koosta leping</button>
+      <button className={tab === "settings" ? "active" : ""} onClick={() => setTab("settings")} role="tab" aria-selected={tab === "settings"}>Mallid ja ettevõtted</button>
+    </div>
+
+    {tab === "history" && <section className="panel contracts-panel"><div className="table-toolbar contracts-filters"><label><Search size={16} /><input aria-label="Otsi lepinguid" value={query} onChange={(event) => setQuery(event.target.value)} placeholder="Otsi numbri, müüja või ostja järgi" /></label><label>Olek<select value={status} onChange={(event) => setStatus(event.target.value)}><option value="ALL">Kõik</option><option value="ACTIVE">Aktiivne</option><option value="ARCHIVED">Arhiveeritud</option></select></label><label>Alates<input type="date" value={fromDate} onChange={(event) => setFromDate(event.target.value)} /></label><label>Kuni<input type="date" value={toDate} onChange={(event) => setToDate(event.target.value)} /></label></div>
+      {loading ? <div className="empty-state">Laadin lepingute registrit…</div> : <div className="data-table"><div className="table-row table-header"><span>Leping</span><span>Pooled</span><span>Koostatud</span><span>Olek</span><span>Toimingud</span></div>{filteredContracts.map((contract) => <div className="table-row" key={contract.id}><span><strong>{contract.contractNo || contract.id}</strong><small>{contract.templateVersion?.name || "Mallita ajalookirje"}</small></span><span>{contract.sellers || "—"}<small>{contract.buyer || "Ostja puudub"}</small></span><span>{formatDate(contract.created)}</span><span><span className={`status-pill ${contract.status === "ARCHIVED" ? "warning" : ""}`}>{contract.status}</span></span><span className="contract-actions"><button className="secondary-action" onClick={() => void openDetail(contract)}><Eye size={15} /> Vaata</button><button className="secondary-action" onClick={() => void api.download(`/services/contracts/${encodeURIComponent(contract.id)}/pdf`, `${contract.contractNo || contract.id}.pdf`).catch((reason) => setError(apiError(reason, "PDF-i ei saanud alla laadida.")))}><Download size={15} /> PDF</button></span></div>)}{!filteredContracts.length && <div className="empty-state">Filtritele vastavaid lepinguid ei leitud.</div>}</div>}
+    </section>}
+
+    {tab === "create" && <section className="contracts-grid"><article className="panel p-5"><div className="panel-heading"><div><p className="eyebrow">1. TEHING</p><h3>Vali võidetud tehing</h3></div><FilePlus2 size={19} /></div><p className="mb-4 text-sm text-muted-foreground">Ava see vaade omaniku töökaardilt või sisesta tehingu tunnus. Server kontrollib aktsepteeritud pakkumist ja kaasatud kinnistuid.</p><div className="contract-inline-form"><input aria-label="Tehingu tunnus" value={dealId} onChange={(event) => setDealId(event.target.value)} placeholder="Tehingu UUID" /><button className="secondary-action" onClick={() => void loadDraft()}>Laadi tehing</button></div>{draft && <div className="contract-draft"><strong>{draft.seller.name}</strong><p>{draft.parcels.length} kinnistut · aktsepteeritud hind {draft.acceptedPrice ?? "—"} €</p><p>{draft.parcels.map((parcel) => parcel.cadastralCode).join(", ")}</p></div>}</article>
+      <article className="panel p-5"><div className="panel-heading"><div><p className="eyebrow">2. MALL JA ETTEVÕTE</p><h3>Koosta eelvaade</h3></div><Settings2 size={19} /></div><label className="contract-field">Lepingumall<select aria-label="Lepingumall" value={templateId} onChange={(event) => { setTemplateId(event.target.value); setPreviewHtml(""); }}><option value="">Vali aktiivne mall</option>{activeTemplates.map((template) => <option key={template.id} value={template.id}>{template.name} · v{template.version}</option>)}</select></label>{chosenTemplate && <div className="contract-draft"><strong>{chosenProfile?.legalName || "Ettevõtteprofiilita mall"}</strong><p>{chosenTemplate.description || "Malli kirjeldus puudub."}</p></div>}<label className="contract-field">Lepingu number<input value={contractNumber} onChange={(event) => setContractNumber(event.target.value)} placeholder="FIQ-2026-0001" /></label><div className="mt-4 flex flex-wrap gap-2"><button className="secondary-action" disabled={!draft || !chosenTemplate} onClick={() => void preview()}><Eye size={16} /> Eelvaade</button><button className="primary-action" disabled={!draft || !chosenTemplate || !contractNumber.trim()} onClick={() => void generate()}><FilePlus2 size={16} /> Genereeri PDF</button></div></article>
+      {previewHtml && <article className="panel p-5 contracts-preview"><p className="eyebrow">MALLI EELVAADE</p><iframe title="Lepingumalli eelvaade" sandbox="" srcDoc={previewHtml} /></article>}
+    </section>}
+
+    {tab === "settings" && <section className="contracts-grid"><article className="panel p-5"><div className="panel-heading"><div><p className="eyebrow">ETTEVÕTTEPROFIILID</p><h3>{editingProfile ? "Muuda ettevõtet" : "Lisa ettevõte"}</h3></div><Plus size={19} /></div><form className="contract-form" onSubmit={createProfile}><input required value={profileForm.legalName} onChange={(event) => setProfileForm({ ...profileForm, legalName: event.target.value })} placeholder="Juriidiline nimi" /><input value={profileForm.registryCode} onChange={(event) => setProfileForm({ ...profileForm, registryCode: event.target.value })} placeholder="Registrikood" /><input value={profileForm.address} onChange={(event) => setProfileForm({ ...profileForm, address: event.target.value })} placeholder="Aadress" /><input type="email" value={profileForm.email} onChange={(event) => setProfileForm({ ...profileForm, email: event.target.value })} placeholder="E-post" /><input value={profileForm.phone} onChange={(event) => setProfileForm({ ...profileForm, phone: event.target.value })} placeholder="Telefon" /><input value={profileForm.iban} onChange={(event) => setProfileForm({ ...profileForm, iban: event.target.value })} placeholder="IBAN" /><input value={profileForm.signatoryName} onChange={(event) => setProfileForm({ ...profileForm, signatoryName: event.target.value })} placeholder="Allkirjastaja nimi" /><input value={profileForm.website} onChange={(event) => setProfileForm({ ...profileForm, website: event.target.value })} placeholder="Veebileht" /><div className="contract-form-actions"><button className="primary-action" type="submit">{editingProfile ? "Uuenda ettevõte" : "Salvesta ettevõte"}</button>{editingProfile && <button className="secondary-action" type="button" onClick={() => { setEditingProfile(null); setProfileForm(blankProfile); }}>Tühista</button>}</div></form><div className="contract-list">{profiles.map((profile) => <div key={profile.id}><div><strong>{profile.legalName}</strong><span>{profile.registryCode || "Registrikood puudub"}</span></div><div className="contract-list-actions"><button type="button" onClick={() => beginProfileEdit(profile)}>Muuda</button><button type="button" onClick={() => void deleteProfile(profile)}>Kustuta</button></div></div>)}{!profiles.length && <p>Ettevõtteprofiile pole veel lisatud.</p>}</div></article>
+      <article className="panel p-5"><div className="panel-heading"><div><p className="eyebrow">LEPINGUMALLID</p><h3>{editingTemplate ? "Reviseeri malli" : "Lisa aktiivne mall"}</h3></div><Plus size={19} /></div><form className="contract-form" onSubmit={createTemplate}><input required value={templateForm.templateKey} onChange={(event) => setTemplateForm({ ...templateForm, templateKey: event.target.value })} placeholder="Malli võti, nt ostu-muuk" /><input required value={templateForm.name} onChange={(event) => setTemplateForm({ ...templateForm, name: event.target.value })} placeholder="Malli nimi" /><select value={templateForm.companyProfileId} onChange={(event) => setTemplateForm({ ...templateForm, companyProfileId: event.target.value })}><option value="">Ettevõtteprofiil puudub</option>{profiles.map((profile) => <option key={profile.id} value={profile.id}>{profile.legalName}</option>)}</select><textarea required value={templateForm.description} onChange={(event) => setTemplateForm({ ...templateForm, description: event.target.value })} placeholder="Kirjeldus" /><textarea required value={templateForm.html} onChange={(event) => setTemplateForm({ ...templateForm, html: event.target.value })} placeholder="Malli HTML" rows={9} /><div className="contract-form-actions"><button className="primary-action" type="submit">{editingTemplate ? "Loo uus malliversioon" : "Salvesta mall"}</button>{editingTemplate && <button className="secondary-action" type="button" onClick={() => { setEditingTemplate(null); setTemplateForm(blankTemplate); }}>Tühista</button>}</div></form><div className="contract-list">{templates.map((template) => <div key={template.id}><div><strong>{template.name}</strong><span>{template.templateKey} · v{template.version} · {template.isActive ? "aktiivne" : "arhiveeritud"}</span></div>{template.isActive && <div className="contract-list-actions"><button type="button" onClick={() => beginTemplateEdit(template)}>Muuda</button><button type="button" onClick={() => void archiveTemplate(template)}>Arhiveeri</button></div>}</div>)}{!templates.length && <p>Aktiivseid malle pole veel lisatud.</p>}</div></article>
+    </section>}
+
+    {selected && <div className="contract-modal-backdrop" role="presentation" onMouseDown={() => setSelected(null)}><article className="panel contract-modal" role="dialog" aria-modal="true" aria-labelledby="contract-detail-title" onMouseDown={(event) => event.stopPropagation()}><div className="panel-heading"><div><p className="eyebrow">LEPINGU DETAIL</p><h3 id="contract-detail-title">{selected.contractNo || selected.id}</h3></div><button className="secondary-action" onClick={() => setSelected(null)}>Sulge</button></div><dl><dt>Müüja</dt><dd>{selected.sellers || "—"}</dd><dt>Ostja</dt><dd>{selected.buyer || "—"}</dd><dt>Koostatud</dt><dd>{formatDate(selected.created)}</dd><dt>Säilitustähtaeg</dt><dd>{formatDate(selected.retentionUntil)}</dd><dt>Mall</dt><dd>{selected.templateVersion?.name || "Ajalooline mall puudub"}</dd></dl>{detail && <details><summary>Tehnilised lepinguandmed</summary><pre>{JSON.stringify(detail, null, 2)}</pre></details>}<div className="mt-5 flex flex-wrap gap-2"><button className="secondary-action" onClick={() => void api.download(`/services/contracts/${encodeURIComponent(selected.id)}/pdf`, `${selected.contractNo || selected.id}.pdf`).catch((reason) => setError(apiError(reason, "PDF-i ei saanud alla laadida.")))}><Download size={16} /> Laadi PDF</button>{selected.status === "ACTIVE" && <button className="secondary-action" onClick={() => void archive(selected)}>Arhiveeri</button>}{selected.ownerId && <Link className="secondary-action" href={`/owners/${selected.ownerId}`}>Ava omanik</Link>}</div></article></div>}
+  </AppShell>;
+}

--- a/forestiq-ui/e2e/critical-workflows.spec.ts
+++ b/forestiq-ui/e2e/critical-workflows.spec.ts
@@ -21,7 +21,7 @@ test("login opens the deterministic development workspace", async ({
   await expect(page.getByText("Töölaud").first()).toBeVisible();
 });
 
-test("owner workflow completes evaluation, offer and contract draft", async ({
+test("owner workflow completes evaluation, offer and template-based contract generation", async ({
   page,
 }) => {
   await authenticateSeededUser(page);
@@ -34,11 +34,15 @@ test("owner workflow completes evaluation, offer and contract draft", async ({
   await page.getByRole("button", { name: "Kinnita hindamine" }).click();
   await page.getByLabel("Pakkumise summa").fill("125000");
   await page.getByRole("button", { name: "Saada pakkumine" }).click();
-  await page.getByRole("button", { name: "Koosta lepingu draft" }).click();
-
-  await expect(
-    page.getByText("Lepingu contract-0001 draft on loodud."),
-  ).toBeVisible();
+  await page.getByRole("link", { name: "Koosta leping" }).click();
+  await expect(page.getByRole("heading", { name: "Lepingute tööala", level: 1 })).toBeVisible();
+  await page.getByRole("button", { name: "Laadi tehing" }).click();
+  await expect(page.getByText("Metsaomanik Mari").last()).toBeVisible();
+  await expect(page.getByText("ForestIQ OÜ").last()).toBeVisible();
+  await page.getByRole("button", { name: "Eelvaade" }).click();
+  await expect(page.getByTitle("Lepingumalli eelvaade")).toBeVisible();
+  await page.getByRole("button", { name: "Genereeri PDF" }).click();
+  await expect(page.getByText("Leping contract-0001 loodi serveripoolse PDF-iga.")).toBeVisible();
 });
 
 test("owner workflow creates and starts an inheritance case", async ({

--- a/forestiq-ui/e2e/seed.ts
+++ b/forestiq-ui/e2e/seed.ts
@@ -70,6 +70,9 @@ export async function installSeededApi(page: Page) {
       offers: [],
     },
   ];
+  const contracts: Array<Record<string, unknown>> = [];
+  const companyProfiles = [{ id: "company-0001", legalName: "ForestIQ OÜ", version: 1 }];
+  const contractTemplates = [{ id: "template-0001", companyProfileId: "company-0001", templateKey: "forest-sale", name: "Metsamüügi leping", description: "QA lepingumall", html: "<h1>{{ company.legalName }}</h1><p>{{ deal.ownerName }}</p>", version: 1, isActive: true }];
   const inheritanceCases = [
     {
       id: "case-0001",
@@ -225,11 +228,23 @@ export async function installSeededApi(page: Page) {
       };
       return json(route, deals[0]);
     }
+    if (pathname === "/api/services/contracts" && method === "GET")
+      return json(route, contracts);
+    if (pathname === "/api/services/contract-templates" && method === "GET")
+      return json(route, contractTemplates);
+    if (pathname === "/api/services/company-profiles" && method === "GET")
+      return json(route, companyProfiles);
+    if (pathname === "/api/services/contracts/deals/deal-0001/draft" && method === "GET")
+      return json(route, { dealId: "deal-0001", dealVersion: 4, offerEntryId: "offer-0001", acceptedPrice: 125000, acceptedTerms: "QA terms", seller: { name: owner.name, code: owner.id }, parcels: [{ cadastralCode: owner.cadastres[0].id, address: owner.address, areaHectares: 12.4 }] });
+    if (pathname === "/api/services/contract-templates/template-0001/preview" && method === "POST")
+      return json(route, { templateId: "template-0001", dealId: "deal-0001", html: "<h1>ForestIQ OÜ</h1><p>Metsaomanik Mari</p>" });
     if (
       pathname === "/api/services/contracts/generate-from-deal" &&
       method === "POST"
-    )
-      return json(route, { contractId: "contract-0001" }, 201);
+    ) {
+      contracts.unshift({ id: "contract-0001", version: 1, sellers: owner.name, buyer: "ForestIQ OÜ", contractNo: "FIQ-2026-DEAL", created: "2026-09-01T12:00:00Z", status: "ACTIVE", dealId: "deal-0001", ownerId: owner.id, templateVersion: { templateId: "template-0001", name: "Metsamüügi leping" } });
+      return json(route, { contractId: "contract-0001", pdf: "/services/contracts/contract-0001/pdf" }, 201);
+    }
     if (pathname.includes("/official-notices/check") && method === "POST")
       return json(route, { notices: [] });
     if (


### PR DESCRIPTION
## Kokkuvõte

See muudatus asendab `/contracts` senise üldise JSON-vaate spetsialiseeritud lepingute tööalaga. Administraator saab otsida lepinguajalugu numbri, osapoolte, staatuse ja kuupäevavahemiku järgi; avada detaili; arhiveerida aktiivse lepingu; ning laadida PDF-i alla autentitud päringuga.

Võidetud tehingu omaniku töökaardil avab **Koosta leping** nüüd lepingute tööala koos tehingu süvalingiga. Tööala laadib serverist kontrollitud drafti, võimaldab valida aktiivse ettevõtteprofiiliga seotud malli, kuvab sandboxitud serveripoolse eelvaate ning genereerib PDF-i vajaliku tehinguversiooniga.

Mallide ja ettevõtteprofiilide vaade toetab loomist, muutmist, malliversiooni loomist, mallide arhiveerimist ning ettevõtteprofiilide kustutamist. Kõik toimingud kasutavad olemasolevat tenant-scoped admin-API-d ning versioonilukustust seal, kus server seda nõuab.

## Kontrollid

| Kontroll | Tulemus |
|---|---|
| Frontend Vitest | Läbis; 11 testi |
| Frontend typecheck | Läbis |
| Frontend lint | Läbis |
| Frontend tootmisehitus | Läbis |
| Lepingute konfiguratsiooni, ajaloo ja workflow serveritestid SpatiaLite’is | Läbis; 14 testi |
| `manage.py check` ja Python-süntaks | Läbis |

Closes #34.
