### PR TITLE
feat(migration): add guarded legacy cutover and reconciliation

### DIFF
--- a/django_backend/forestry/management/commands/migrate_legacy_cutover.py
+++ b/django_backend/forestry/management/commands/migrate_legacy_cutover.py
@@ -1,0 +1,57 @@
+"""Safe operator wrapper around the legacy MetsIS importer.
+
+Dry-run is the default. A real write requires --confirm-write and records a
+checkpoint artifact so an interrupted cutover can be resumed deterministically.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from django.core.management import call_command
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+from django.utils import timezone
+
+
+class Command(BaseCommand):
+    help = "Run the legacy cutover importer with dry-run, checkpoint and resume safeguards."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--organization", required=True)
+        parser.add_argument("--confirm-write", action="store_true")
+        parser.add_argument("--checkpoint", default="legacy-cutover-checkpoint.json")
+        parser.add_argument("--resume", action="store_true")
+        parser.add_argument("--quarantine", default="legacy-cutover-quarantine.jsonl")
+
+    def handle(self, *args, **options):
+        checkpoint_path = Path(options["checkpoint"])
+        if options["resume"] and checkpoint_path.exists():
+            checkpoint = json.loads(checkpoint_path.read_text(encoding="utf-8"))
+            if checkpoint.get("status") == "completed":
+                self.stdout.write(self.style.SUCCESS("Checkpoint is already completed; nothing to resume."))
+                return
+        elif options["resume"]:
+            raise CommandError("--resume requires an existing checkpoint file.")
+
+        checkpoint = {
+            "organization": options["organization"],
+            "startedAt": timezone.now().isoformat(),
+            "status": "running",
+            "mode": "write" if options["confirm_write"] else "dry-run",
+            "quarantine": options["quarantine"],
+        }
+        checkpoint_path.write_text(json.dumps(checkpoint, indent=2), encoding="utf-8")
+
+        if options["confirm_write"]:
+            call_command("import_legacy_metsis", "--confirm", "--organization", options["organization"])
+        else:
+            # Run the exact importer against the target transaction and force rollback.
+            # Source is opened read-only by convention; target writes never escape dry-run.
+            with transaction.atomic():
+                call_command("import_legacy_metsis", "--confirm", "--organization", options["organization"])
+                transaction.set_rollback(True)
+
+        checkpoint.update({"status": "completed", "finishedAt": timezone.now().isoformat()})
+        checkpoint_path.write_text(json.dumps(checkpoint, indent=2), encoding="utf-8")
+        self.stdout.write(self.style.SUCCESS(f"Legacy cutover {checkpoint['mode']} completed."))

--- a/django_backend/forestry/management/commands/migrate_legacy_cutover.py
+++ b/django_backend/forestry/management/commands/migrate_legacy_cutover.py
@@ -2,20 +2,74 @@
 
 Dry-run is the default. A real write requires --confirm-write and records a
 checkpoint artifact so an interrupted cutover can be resumed deterministically.
+Malformed source rows are quarantined during preflight and block writes instead
+of being silently discarded.
 """
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
+import psycopg
+from psycopg.errors import UndefinedTable
+from psycopg.rows import dict_row
 from django.core.management import call_command
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
 from django.utils import timezone
 
 
+PREFLIGHT_KEYS = {
+    "users": ("id",),
+    "privileges": ("id", "user_id"),
+    "owners": ("id",),
+    "cadastres": ("id",),
+    "owner_cadastre": ("owner_id", "cadastre_id"),
+    "cadastre_labels": ("id", "cadastre_id"),
+    "cadastre_sub_parts": ("cadastre_id", "sub_part_code"),
+    "cadastre_notifications": ("id", "notification_number", "cadastre_id"),
+    "forest_registry_features": ("source_layer", "source_id", "cadastre_id"),
+    "owner_log": ("id", "owner_id", "creator"),
+    "persons_dump": ("id",),
+    "reminders": ("id", "duetime"),
+    "contracts": ("id",),
+    "contract_history": ("id",),
+}
+
+
+def _quarantine_source_rows(source_url: str, output: Path) -> int:
+    """Preflight required identity/relationship fields and write bad rows as JSONL."""
+    quarantined = []
+    with psycopg.connect(source_url, row_factory=dict_row) as source:
+        for table, required in PREFLIGHT_KEYS.items():
+            try:
+                with source.cursor() as cursor:
+                    cursor.execute(f'SELECT * FROM "{table}"')
+                    for row_number, row in enumerate(cursor, start=1):
+                        missing = [key for key in required if row.get(key) in (None, "")]
+                        if missing:
+                            quarantined.append(
+                                {
+                                    "table": table,
+                                    "rowNumber": row_number,
+                                    "reason": "missing_required_fields",
+                                    "fields": missing,
+                                    "row": dict(row),
+                                }
+                            )
+            except UndefinedTable:
+                source.rollback()
+                continue
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with output.open("w", encoding="utf-8") as handle:
+        for item in quarantined:
+            handle.write(json.dumps(item, ensure_ascii=False, default=str) + "\n")
+    return len(quarantined)
+
+
 class Command(BaseCommand):
-    help = "Run the legacy cutover importer with dry-run, checkpoint and resume safeguards."
+    help = "Run the legacy cutover importer with dry-run, quarantine, checkpoint and resume safeguards."
 
     def add_arguments(self, parser):
         parser.add_argument("--organization", required=True)
@@ -25,7 +79,11 @@ class Command(BaseCommand):
         parser.add_argument("--quarantine", default="legacy-cutover-quarantine.jsonl")
 
     def handle(self, *args, **options):
+        source_url = os.getenv("LEGACY_DATABASE_URL")
+        if not source_url:
+            raise CommandError("LEGACY_DATABASE_URL is required.")
         checkpoint_path = Path(options["checkpoint"])
+        quarantine_path = Path(options["quarantine"])
         if options["resume"] and checkpoint_path.exists():
             checkpoint = json.loads(checkpoint_path.read_text(encoding="utf-8"))
             if checkpoint.get("status") == "completed":
@@ -37,20 +95,42 @@ class Command(BaseCommand):
         checkpoint = {
             "organization": options["organization"],
             "startedAt": timezone.now().isoformat(),
-            "status": "running",
+            "status": "preflight",
             "mode": "write" if options["confirm_write"] else "dry-run",
-            "quarantine": options["quarantine"],
+            "quarantine": str(quarantine_path),
+            "resumeStrategy": "idempotent replay from source",
         }
+        checkpoint_path.parent.mkdir(parents=True, exist_ok=True)
         checkpoint_path.write_text(json.dumps(checkpoint, indent=2), encoding="utf-8")
 
-        if options["confirm_write"]:
-            call_command("import_legacy_metsis", "--confirm", "--organization", options["organization"])
-        else:
-            # Run the exact importer against the target transaction and force rollback.
-            # Source is opened read-only by convention; target writes never escape dry-run.
-            with transaction.atomic():
+        quarantined = _quarantine_source_rows(source_url, quarantine_path)
+        checkpoint["quarantinedRows"] = quarantined
+        if quarantined:
+            checkpoint.update({"status": "blocked", "finishedAt": timezone.now().isoformat()})
+            checkpoint_path.write_text(json.dumps(checkpoint, indent=2), encoding="utf-8")
+            raise CommandError(
+                f"Cutover blocked: {quarantined} malformed source row(s) were written to {quarantine_path}."
+            )
+
+        checkpoint["status"] = "running"
+        checkpoint_path.write_text(json.dumps(checkpoint, indent=2), encoding="utf-8")
+        try:
+            if options["confirm_write"]:
                 call_command("import_legacy_metsis", "--confirm", "--organization", options["organization"])
-                transaction.set_rollback(True)
+            else:
+                # Run the exact importer against the target transaction and force rollback.
+                # Source is opened separately; target writes never escape dry-run.
+                with transaction.atomic():
+                    call_command("import_legacy_metsis", "--confirm", "--organization", options["organization"])
+                    transaction.set_rollback(True)
+        except Exception as exc:
+            checkpoint.update({
+                "status": "failed",
+                "finishedAt": timezone.now().isoformat(),
+                "error": str(exc)[:4000],
+            })
+            checkpoint_path.write_text(json.dumps(checkpoint, indent=2), encoding="utf-8")
+            raise
 
         checkpoint.update({"status": "completed", "finishedAt": timezone.now().isoformat()})
         checkpoint_path.write_text(json.dumps(checkpoint, indent=2), encoding="utf-8")

--- a/django_backend/forestry/management/commands/reconcile_legacy_cutover.py
+++ b/django_backend/forestry/management/commands/reconcile_legacy_cutover.py
@@ -10,7 +10,7 @@ import psycopg
 from psycopg.rows import dict_row
 from django.core.management.base import BaseCommand, CommandError
 
-from accounts.models import OrganizationMembership, User
+from accounts.models import OrganizationMembership
 from accounts.organization_context import organization_scope
 from accounts.organization_selection import active_organization
 from forestry.models import Cadastre, CadastreNotification, CadastreSubPart, Owner, OwnerCadastre, OwnerLog
@@ -33,6 +33,14 @@ def _hash_rows(rows, keys):
     digest = hashlib.sha256()
     for row in sorted(rows, key=lambda item: tuple(str(item.get(key, "")) for key in keys)):
         digest.update("|".join(str(row.get(key, "")) for key in keys).encode("utf-8"))
+        digest.update(b"\n")
+    return digest.hexdigest()
+
+
+def _hash_values(values):
+    digest = hashlib.sha256()
+    for value in sorted(str(item) for item in values):
+        digest.update(value.encode("utf-8"))
         digest.update(b"\n")
     return digest.hexdigest()
 
@@ -70,7 +78,11 @@ class Command(BaseCommand):
                     "available": True,
                     "count": len(rows),
                     "ids": ids,
-                    "checksum": _hash_rows(rows, ["id"] if any("id" in row for row in rows) else list(rows[0].keys())[:2] if rows else ["id"]),
+                    "checksum": _hash_rows(
+                        rows,
+                        ["id"] if any("id" in row for row in rows)
+                        else list(rows[0].keys())[:2] if rows else ["id"],
+                    ),
                 }
 
         with organization_scope(organization.id):
@@ -91,7 +103,6 @@ class Command(BaseCommand):
         for key, legacy_info in legacy.items():
             target = django_sets.get(key, set())
             source_ids = set(legacy_info.get("ids", []))
-            # Relationship tables may not expose the same synthetic IDs, so count remains the stable gate there.
             comparable_ids = key not in {"ownerCadastres", "subparts"}
             missing = sorted(source_ids - set(map(str, target))) if comparable_ids else []
             extra = sorted(set(map(str, target)) - source_ids) if comparable_ids else []
@@ -107,6 +118,7 @@ class Command(BaseCommand):
                 "djangoCount": len(target),
                 "countDelta": delta,
                 "legacyChecksum": legacy_info.get("checksum"),
+                "djangoIdentityChecksum": _hash_values(target),
                 "missingIds": missing[:100],
                 "extraIds": extra[:100],
                 "missingCount": len(missing),
@@ -114,14 +126,21 @@ class Command(BaseCommand):
                 "passed": passed,
             }
         report = {
-            "organization": str(organization.id),
+            "organization": {
+                "id": str(organization.id),
+                "slug": organization.slug,
+                "active": organization.is_active,
+                "membershipCount": len(django_sets["users"]),
+            },
             "go": go,
             "thresholds": {"maxCountDelta": options["max_count_delta"], "maxMissingIds": options["max_missing_ids"]},
             "comparisons": comparisons,
             "note": "Deals are Django-native and are reported independently because legacy MetsIS did not have the same deal aggregate.",
-            "djangoDealCount": len(django_sets["deals"]),
+            "djangoDeals": {"count": len(django_sets["deals"]), "identityChecksum": _hash_values(django_sets["deals"])},
         }
-        Path(options["output"]).write_text(json.dumps(report, indent=2, ensure_ascii=False), encoding="utf-8")
+        output = Path(options["output"])
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(json.dumps(report, indent=2, ensure_ascii=False), encoding="utf-8")
         self.stdout.write(json.dumps(report, indent=2, ensure_ascii=False))
         if not go:
             raise CommandError("Cutover reconciliation failed go/no-go thresholds.")

--- a/django_backend/forestry/management/commands/reconcile_legacy_cutover.py
+++ b/django_backend/forestry/management/commands/reconcile_legacy_cutover.py
@@ -1,0 +1,127 @@
+"""Generate a deterministic legacy-vs-Django cutover readiness report."""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+
+import psycopg
+from psycopg.rows import dict_row
+from django.core.management.base import BaseCommand, CommandError
+
+from accounts.models import OrganizationMembership, User
+from accounts.organization_context import organization_scope
+from accounts.organization_selection import active_organization
+from forestry.models import Cadastre, CadastreNotification, CadastreSubPart, Owner, OwnerCadastre, OwnerLog
+from operations.models import Contract, Deal
+
+
+LEGACY_TABLES = {
+    "users": "users",
+    "owners": "owners",
+    "cadastres": "cadastres",
+    "ownerCadastres": "owner_cadastre",
+    "subparts": "cadastre_sub_parts",
+    "notices": "cadastre_notifications",
+    "contracts": "contracts",
+    "audits": "owner_log",
+}
+
+
+def _hash_rows(rows, keys):
+    digest = hashlib.sha256()
+    for row in sorted(rows, key=lambda item: tuple(str(item.get(key, "")) for key in keys)):
+        digest.update("|".join(str(row.get(key, "")) for key in keys).encode("utf-8"))
+        digest.update(b"\n")
+    return digest.hexdigest()
+
+
+class Command(BaseCommand):
+    help = "Compare legacy MetsIS counts/checksums with Django and emit a go/no-go report."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--organization", required=True)
+        parser.add_argument("--output", default="cutover-reconciliation.json")
+        parser.add_argument("--max-count-delta", type=int, default=0)
+        parser.add_argument("--max-missing-ids", type=int, default=0)
+
+    def handle(self, *args, **options):
+        source_url = os.getenv("LEGACY_DATABASE_URL")
+        if not source_url:
+            raise CommandError("LEGACY_DATABASE_URL is required.")
+        organization = active_organization(options["organization"])
+        if organization is None:
+            raise CommandError("Unknown or inactive organization.")
+
+        legacy = {}
+        with psycopg.connect(source_url, row_factory=dict_row) as source:
+            for key, table in LEGACY_TABLES.items():
+                with source.cursor() as cursor:
+                    try:
+                        cursor.execute(f'SELECT * FROM "{table}"')
+                        rows = cursor.fetchall()
+                    except Exception as exc:
+                        source.rollback()
+                        legacy[key] = {"available": False, "error": str(exc), "count": 0, "ids": []}
+                        continue
+                ids = [str(row.get("id")) for row in rows if row.get("id") is not None]
+                legacy[key] = {
+                    "available": True,
+                    "count": len(rows),
+                    "ids": ids,
+                    "checksum": _hash_rows(rows, ["id"] if any("id" in row for row in rows) else list(rows[0].keys())[:2] if rows else ["id"]),
+                }
+
+        with organization_scope(organization.id):
+            django_sets = {
+                "users": set(OrganizationMembership.objects.filter(organization=organization).values_list("user_id", flat=True)),
+                "owners": set(Owner.objects.values_list("id", flat=True)),
+                "cadastres": set(Cadastre.objects.values_list("id", flat=True)),
+                "ownerCadastres": {f"{owner}:{cad}" for owner, cad in OwnerCadastre.objects.values_list("owner_id", "cadastre_id")},
+                "subparts": {f"{cad}:{code}" for cad, code in CadastreSubPart.objects.values_list("cadastre_id", "sub_part_code")},
+                "notices": set(str(value) for value in CadastreNotification.objects.values_list("id", flat=True)),
+                "contracts": set(str(value) for value in Contract.objects.values_list("id", flat=True)),
+                "audits": set(str(value) for value in OwnerLog.objects.values_list("id", flat=True)),
+                "deals": set(str(value) for value in Deal.objects.values_list("id", flat=True)),
+            }
+
+        comparisons = {}
+        go = True
+        for key, legacy_info in legacy.items():
+            target = django_sets.get(key, set())
+            source_ids = set(legacy_info.get("ids", []))
+            # Relationship tables may not expose the same synthetic IDs, so count remains the stable gate there.
+            comparable_ids = key not in {"ownerCadastres", "subparts"}
+            missing = sorted(source_ids - set(map(str, target))) if comparable_ids else []
+            extra = sorted(set(map(str, target)) - source_ids) if comparable_ids else []
+            delta = len(target) - int(legacy_info.get("count", 0))
+            passed = (
+                legacy_info.get("available", False)
+                and abs(delta) <= options["max_count_delta"]
+                and len(missing) <= options["max_missing_ids"]
+            )
+            go = go and passed
+            comparisons[key] = {
+                "legacyCount": legacy_info.get("count", 0),
+                "djangoCount": len(target),
+                "countDelta": delta,
+                "legacyChecksum": legacy_info.get("checksum"),
+                "missingIds": missing[:100],
+                "extraIds": extra[:100],
+                "missingCount": len(missing),
+                "extraCount": len(extra),
+                "passed": passed,
+            }
+        report = {
+            "organization": str(organization.id),
+            "go": go,
+            "thresholds": {"maxCountDelta": options["max_count_delta"], "maxMissingIds": options["max_missing_ids"]},
+            "comparisons": comparisons,
+            "note": "Deals are Django-native and are reported independently because legacy MetsIS did not have the same deal aggregate.",
+            "djangoDealCount": len(django_sets["deals"]),
+        }
+        Path(options["output"]).write_text(json.dumps(report, indent=2, ensure_ascii=False), encoding="utf-8")
+        self.stdout.write(json.dumps(report, indent=2, ensure_ascii=False))
+        if not go:
+            raise CommandError("Cutover reconciliation failed go/no-go thresholds.")

--- a/django_backend/forestry/tests_cutover_tools.py
+++ b/django_backend/forestry/tests_cutover_tools.py
@@ -1,0 +1,107 @@
+"""Regression tests for guarded legacy cutover tooling."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import TestCase
+
+from forestry.management.commands.reconcile_legacy_cutover import _hash_rows
+
+
+class LegacyCutoverCommandTests(TestCase):
+    @patch.dict("os.environ", {"LEGACY_DATABASE_URL": "postgresql://readonly@example.test/metsis"})
+    @patch("forestry.management.commands.migrate_legacy_cutover.call_command")
+    @patch("forestry.management.commands.migrate_legacy_cutover._quarantine_source_rows", return_value=0)
+    def test_dry_run_rolls_back_after_running_the_importer(self, quarantine, importer):
+        with TemporaryDirectory() as directory:
+            checkpoint = Path(directory) / "checkpoint.json"
+            quarantine_file = Path(directory) / "quarantine.jsonl"
+            call_command(
+                "migrate_legacy_cutover",
+                "--organization",
+                "demo",
+                "--checkpoint",
+                str(checkpoint),
+                "--quarantine",
+                str(quarantine_file),
+            )
+
+            state = json.loads(checkpoint.read_text(encoding="utf-8"))
+
+        importer.assert_called_once_with("import_legacy_metsis", "--confirm", "--organization", "demo")
+        quarantine.assert_called_once()
+        self.assertEqual(state["mode"], "dry-run")
+        self.assertEqual(state["status"], "completed")
+        self.assertEqual(state["resumeStrategy"], "idempotent replay from source")
+
+    @patch.dict("os.environ", {"LEGACY_DATABASE_URL": "postgresql://readonly@example.test/metsis"})
+    @patch("forestry.management.commands.migrate_legacy_cutover.call_command")
+    @patch("forestry.management.commands.migrate_legacy_cutover._quarantine_source_rows", return_value=0)
+    def test_confirmed_run_delegates_to_idempotent_importer(self, quarantine, importer):
+        with TemporaryDirectory() as directory:
+            checkpoint = Path(directory) / "checkpoint.json"
+            call_command(
+                "migrate_legacy_cutover",
+                "--organization",
+                "demo",
+                "--confirm-write",
+                "--checkpoint",
+                str(checkpoint),
+                "--quarantine",
+                str(Path(directory) / "quarantine.jsonl"),
+            )
+            state = json.loads(checkpoint.read_text(encoding="utf-8"))
+
+        importer.assert_called_once_with("import_legacy_metsis", "--confirm", "--organization", "demo")
+        quarantine.assert_called_once()
+        self.assertEqual(state["mode"], "write")
+        self.assertEqual(state["status"], "completed")
+
+    @patch.dict("os.environ", {"LEGACY_DATABASE_URL": "postgresql://readonly@example.test/metsis"})
+    @patch("forestry.management.commands.migrate_legacy_cutover.call_command")
+    @patch("forestry.management.commands.migrate_legacy_cutover._quarantine_source_rows", return_value=2)
+    def test_quarantined_rows_block_any_write(self, quarantine, importer):
+        with TemporaryDirectory() as directory:
+            checkpoint = Path(directory) / "checkpoint.json"
+            with self.assertRaisesMessage(CommandError, "Cutover blocked: 2 malformed source row(s)"):
+                call_command(
+                    "migrate_legacy_cutover",
+                    "--organization",
+                    "demo",
+                    "--confirm-write",
+                    "--checkpoint",
+                    str(checkpoint),
+                    "--quarantine",
+                    str(Path(directory) / "quarantine.jsonl"),
+                )
+            state = json.loads(checkpoint.read_text(encoding="utf-8"))
+
+        quarantine.assert_called_once()
+        importer.assert_not_called()
+        self.assertEqual(state["status"], "blocked")
+        self.assertEqual(state["quarantinedRows"], 2)
+
+    @patch.dict("os.environ", {"LEGACY_DATABASE_URL": "postgresql://readonly@example.test/metsis"})
+    @patch("forestry.management.commands.migrate_legacy_cutover._quarantine_source_rows")
+    def test_completed_checkpoint_makes_resume_idempotent(self, quarantine):
+        with TemporaryDirectory() as directory:
+            checkpoint = Path(directory) / "checkpoint.json"
+            checkpoint.write_text(json.dumps({"status": "completed"}), encoding="utf-8")
+            call_command("migrate_legacy_cutover", "--organization", "demo", "--resume", "--checkpoint", str(checkpoint))
+
+        quarantine.assert_not_called()
+
+
+class LegacyReconciliationHashTests(TestCase):
+    def test_row_checksum_is_order_independent_and_value_sensitive(self):
+        expected = _hash_rows([{"id": "owner-2", "name": "B"}, {"id": "owner-1", "name": "A"}], ["id", "name"])
+        reordered = _hash_rows([{"id": "owner-1", "name": "A"}, {"id": "owner-2", "name": "B"}], ["id", "name"])
+        changed = _hash_rows([{"id": "owner-1", "name": "Changed"}, {"id": "owner-2", "name": "B"}], ["id", "name"])
+
+        self.assertEqual(expected, reordered)
+        self.assertNotEqual(expected, changed)

--- a/docs/CUTOVER_RECOVERY_PERFORMANCE_RUNBOOK.md
+++ b/docs/CUTOVER_RECOVERY_PERFORMANCE_RUNBOOK.md
@@ -1,0 +1,137 @@
+# ForestIQ-D cutover, recovery and performance runbook
+
+This runbook is the operator gate for legacy MetsIS/Java -> ForestIQ-D Django cutover. It covers migration, reconciliation, backup/restore, performance and rollback. Production routing must not be switched until every **GO** gate below is green.
+
+## Recovery objectives and evidence
+
+Project recovery objectives:
+
+- **Database RPO:** <= 24 hours. Take an explicit pre-cutover backup immediately before the write freeze even when the hosting provider also has managed backups.
+- **Uploaded contract/media RPO:** <= 24 hours. Database and media backup timestamps must belong to the same cutover window.
+- **RTO target:** <= 4 hours for restoring database + media to an isolated environment and completing smoke/reconciliation checks.
+- Every backup and restore drill produces a JSON report. Store the report together with the backup artifact or in the incident/cutover ticket.
+
+Create an auditable backup:
+
+```bash
+python scripts/backup_restore.py backup --output backups
+```
+
+The command creates a PostgreSQL custom-format dump, optionally archives `MEDIA_ROOT`, calculates SHA-256 checksums and writes a JSON manifest. Do not consider a backup usable merely because a file exists: a restore drill is the integrity gate.
+
+Restore only into an isolated target database:
+
+```bash
+python scripts/backup_restore.py restore \
+  --dump backups/forestiq-<timestamp>.dump \
+  --sha256 <sha256-from-backup-manifest> \
+  --target-database-url postgresql://.../forestiq_restore_drill \
+  --report restore-report.json
+```
+
+The utility refuses to restore into the active `DATABASE_URL`, runs `pg_restore`, validates the restored database with `SELECT 1`, optionally restores media, and records duration/checksum evidence. For Render persistent-disk deployments, include the mounted media directory in `--media-path`; for S3/object storage, use the bucket's versioning/backup policy and retain the corresponding provider evidence alongside the DB manifest.
+
+## Migration preparation and dry-run
+
+1. Confirm `LEGACY_DATABASE_URL` is a **read-only** credential.
+2. Run target Django migrations and application checks.
+3. Create and verify a backup/restore drill.
+4. Run the migration in dry-run mode; target writes are rolled back:
+
+```bash
+cd django_backend
+python manage.py migrate_legacy_cutover \
+  --organization <organization-id-or-slug> \
+  --checkpoint ../cutover-checkpoint.json \
+  --quarantine ../cutover-quarantine.jsonl
+```
+
+5. Review quarantine output. Any malformed source row is a **NO-GO** until corrected or explicitly resolved. Never silently discard a source row.
+6. Re-run the same command until the dry-run succeeds. The underlying importer uses idempotent `update_or_create`/`get_or_create`; an interrupted run is resumed by safely replaying from the durable source of truth. `--resume` validates the checkpoint and does not bypass validation.
+
+Only after dry-run success may the write run be executed:
+
+```bash
+python manage.py migrate_legacy_cutover \
+  --organization <organization-id-or-slug> \
+  --checkpoint ../cutover-checkpoint.json \
+  --quarantine ../cutover-quarantine.jsonl \
+  --confirm-write
+```
+
+## Automated reconciliation / GO-NO-GO
+
+Run after every migration rehearsal and immediately before traffic switch:
+
+```bash
+python manage.py reconcile_legacy_cutover \
+  --organization <organization-id-or-slug> \
+  --output ../cutover-reconciliation.json \
+  --max-count-delta 0 \
+  --max-missing-ids 0
+```
+
+The report compares source/target counts and identity sets for users, owners, cadastres, owner-cadastre relationships, subparts, notices, contracts and audit entries, and reports the Django-native deal aggregate. Default thresholds are intentionally zero-tolerance. Any missing source identity or count delta is a **NO-GO**; inspect the drill-down IDs before continuing.
+
+## Performance and soak gate
+
+Critical read paths must remain bounded under concurrent access. Run the HTTP profile against a realistic restored dataset:
+
+```bash
+FORESTIQ_SOAK_TOKEN=<access-token> python scripts/soak_profile.py \
+  --base-url https://candidate.example \
+  --path /api/v1/services/map/cadastres \
+  --path /api/v1/services/map/tiles/cadastres/8/145/83.pbf \
+  --requests 500 \
+  --concurrency 16 \
+  --p95-ms 750 \
+  --p99-ms 1500 \
+  --max-error-rate 0.01 \
+  --output soak-profile.json
+```
+
+The command exits non-zero when p95, p99 or the error budget is exceeded. During a long WFS/Celery rehearsal also capture:
+
+- worker RSS before/after and peak RSS;
+- PostgreSQL active/idle connection counts and connection-pool saturation;
+- Celery queue depth, retries and failed task count;
+- `DataSyncRun` overlap behaviour: a second single-flight import must be skipped/reused rather than creating duplicate writes;
+- WFS retry/backoff behaviour with a controlled transient failure;
+- MVT/GeoJSON request p95/p99 from the same restored dataset.
+
+A growing RSS trend, unbounded DB connections, duplicate overlapping imports, unbounded queue growth or a latency/error budget failure is **NO-GO**.
+
+## Production cutover sequence
+
+1. **Preflight:** deployment version recorded; migrations/tests green; backup restore drill successful; dry-run migration and reconciliation green; soak profile green.
+2. **Write freeze:** stop writes in the Java/MetsIS application. Keep reads available if operationally useful. Record exact freeze timestamp.
+3. **Final migration:** run `migrate_legacy_cutover --confirm-write`. If the source changed after the last rehearsal, replay safely from source; idempotency prevents duplicates.
+4. **Final reconciliation:** zero-tolerance reconciliation must return `go: true`.
+5. **Django smoke test:** authenticate; open owner/cadastre/map; create/update a permitted non-destructive test record; verify reminders/messages; verify admin integrations; verify a contract/media read; verify Keycloak login and organization boundary.
+6. **Route switch:** switch Render/custom-domain route or DNS to ForestIQ-D. Record timestamp and old/new target.
+7. **Observe:** monitor HTTP 5xx/4xx anomaly rate, p95/p99, DB connections, Celery failures/backlog, integration freshness and authentication failures.
+8. Keep the legacy application frozen and recoverable for the agreed rollback window; do not resume dual writes.
+
+## Rollback
+
+Rollback immediately when any of these occurs after switch: data reconciliation failure, organization-boundary/security failure, sustained critical 5xx/auth failure, corrupted document access, or operational performance outside the accepted budget.
+
+1. Stop ForestIQ-D writes / maintenance-mode the candidate.
+2. Switch route/DNS back to the frozen legacy application.
+3. If legacy remained frozen and authoritative, resume its writes only after route restoration is confirmed.
+4. Preserve the failed Django database and logs for investigation; do not overwrite evidence.
+5. If the Django target itself must be recovered, restore the verified pre-cutover dump/media into a **new isolated database/storage target**, verify it, and only then promote it.
+6. Record rollback cause, correlation IDs, migration checkpoint, reconciliation report, backup manifest and restore report.
+
+## Trial evidence checklist
+
+A production cutover is **NO-GO** unless at least one rehearsal has produced all of the following artifacts:
+
+- successful dry-run checkpoint;
+- empty/resolved quarantine file;
+- `go: true` reconciliation report;
+- database backup JSON manifest + SHA-256;
+- successful isolated restore JSON report within the RTO target;
+- performance/soak JSON report within budgets;
+- smoke-test notes including auth, owner/cadastre/map, documents and integrations;
+- tested route-switch and rollback steps.


### PR DESCRIPTION
## Kokkuvõte

Puhastatud PR sisaldab ainult veel `main`-is puudunud MIG-01, MIG-02 ja MIG-03 muudatusi. Varem integreeritud API-, Keycloak-, Metsise, telefoniraamatu-, backup- ja jõudlusemuudatused eemaldati rebase’i käigus, et vältida kattuvusi.

- **MIG-01 / #57:** vaikimisi dry-run, sõnaselge `--confirm-write`, checkpoint, `--resume`, idempotentse olemasoleva importija kasutus ja vigaste lähteridade JSONL-quarantine.
- **MIG-02 / #58:** organisatsioonipõhine loendite, identifikaatorite, kontrollsummade, erinevuste ja go/no-go piiridega reconciliation-raport.
- **MIG-03 / #59:** cutover, taastamise, rollback’i ning jõudluse käitusjuhis.

## Lokaalne valideerimine

| Kontroll | Tulemus |
|---|---|
| Guarded cutover ja reconciliation testid SpatiaLite’is | Läbis; 5 testi |
| Django system check | Läbis |
| Uute halduskäskude Python-süntaks | Läbis |

Closes #57
Closes #58
Closes #59