### PR TITLE
fix(api): enforce strict mutation contracts

### DIFF
--- a/django_backend/api/middleware.py
+++ b/django_backend/api/middleware.py
@@ -38,7 +38,10 @@ def _request_payload(request):
         return json.loads(request.body.decode(request.encoding or "utf-8"))
     if "multipart/form-data" in content_type:
         data = request.POST.dict()
-        data.update(request.FILES)
+        # MultiValueDict tuleb kopeerida võtmehaaval: dict.update ei säilita
+        # kõigis Django request-kontekstides failiobjekti usaldusväärselt.
+        for field_name, uploaded_file in request.FILES.items():
+            data[field_name] = uploaded_file
         return data
     return None
 

--- a/django_backend/api/middleware.py
+++ b/django_backend/api/middleware.py
@@ -1,11 +1,16 @@
-"""Request-bound organization and observability context lifecycle middleware."""
+"""Request-bound organization, validation and observability context middleware."""
 
 from __future__ import annotations
 
+import json
 import logging
+import re
 from time import monotonic
 
-from config.observability import reset_correlation_id, safe_correlation_id, set_correlation_id
+from django.http import JsonResponse
+
+from api.mutation_serializers import MUTATION_RULES, MarkCadastresSerializer, validation_error_payload
+from config.observability import current_correlation_id, reset_correlation_id, safe_correlation_id, set_correlation_id
 from config.prometheus import observe_http_request
 
 logger = logging.getLogger(__name__)
@@ -17,8 +22,80 @@ from accounts.organization_context import (
 )
 
 
+def _normalized_api_path(path: str) -> str:
+    if path.startswith("/api/v1/"):
+        return "/" + path[len("/api/v1/") :].lstrip("/")
+    if path.startswith("/api/"):
+        return "/" + path[len("/api/") :].lstrip("/")
+    return path
+
+
+def _request_payload(request):
+    content_type = (request.content_type or "").lower()
+    if "application/json" in content_type:
+        if not request.body:
+            return {}
+        return json.loads(request.body.decode(request.encoding or "utf-8"))
+    if "multipart/form-data" in content_type:
+        data = request.POST.dict()
+        data.update(request.FILES)
+        return data
+    return None
+
+
+def _validate_registered_mutation(request):
+    path = _normalized_api_path(request.path)
+    for method, pattern, serializer_class in MUTATION_RULES:
+        if request.method != method or re.fullmatch(pattern, path) is None:
+            continue
+        try:
+            payload = _request_payload(request)
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            return JsonResponse(
+                validation_error_payload(
+                    {"body": [f"Malformed JSON: {exc.msg if hasattr(exc, 'msg') else str(exc)}"]},
+                    status_code=400,
+                    correlation_id=current_correlation_id(),
+                ),
+                status=400,
+            )
+        if payload is None:
+            return None
+        validation_payload = {"cadastres": payload} if serializer_class is MarkCadastresSerializer and isinstance(payload, list) else payload
+        serializer = serializer_class(data=validation_payload)
+        if not serializer.is_valid():
+            return JsonResponse(
+                validation_error_payload(
+                    serializer.errors,
+                    status_code=400,
+                    correlation_id=current_correlation_id(),
+                ),
+                status=400,
+            )
+        return None
+    return None
+
+
+def _normalize_error_response(response):
+    if getattr(response, "status_code", 200) not in {400, 403, 404, 409} or not hasattr(response, "data"):
+        return response
+    raw = response.data
+    payload = dict(raw) if isinstance(raw, dict) else {"detail": raw}
+    payload.setdefault("detail", "Request failed.")
+    payload.setdefault("code", {
+        400: "bad_request",
+        403: "forbidden",
+        404: "not_found",
+        409: "conflict",
+    }[response.status_code])
+    payload["status"] = response.status_code
+    payload.setdefault("correlationId", current_correlation_id() or None)
+    response.data = payload
+    return response
+
+
 class TraceContextMiddleware:
-    """Attach one safe correlation ID to each HTTP request and response."""
+    """Attach one safe correlation ID and a consistent API error envelope to each request."""
 
     header_name = "X-Correlation-ID"
 
@@ -31,7 +108,10 @@ class TraceContextMiddleware:
         correlation_token = set_correlation_id(correlation_id)
         request.correlation_id = correlation_id
         try:
-            response = self.get_response(request)
+            response = _validate_registered_mutation(request)
+            if response is None:
+                response = self.get_response(request)
+            response = _normalize_error_response(response)
             response[self.header_name] = correlation_id
             observe_http_request(
                 request,

--- a/django_backend/api/mutation_serializers.py
+++ b/django_backend/api/mutation_serializers.py
@@ -192,6 +192,8 @@ class MarkMessagesReadSerializer(serializers.Serializer):
 
 class ContractUploadSerializer(serializers.Serializer):
     file = serializers.FileField(required=True)
+    # Multipart vormiväljad on HTTP-s tekst; DRF teeb siin teadliku vormi-arvu teisenduse.
+    version = serializers.IntegerField(min_value=1)
 
     def validate_file(self, upload):
         if getattr(upload, "content_type", "") not in {"application/pdf", "application/x-pdf"}:

--- a/django_backend/api/mutation_serializers.py
+++ b/django_backend/api/mutation_serializers.py
@@ -1,0 +1,230 @@
+"""Strict DRF input serializers for legacy-compatible ForestIQ mutation endpoints.
+
+The legacy API accepts a number of historical field names, but it must not silently
+coerce booleans, numbers or collection values into another type. These serializers
+are intentionally validation-only: existing views keep their response compatibility
+while every registered mutation is type-checked before it reaches persistence code.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from django.utils.dateparse import parse_datetime
+from rest_framework import serializers
+
+from accounts.models import PrivilegeCode
+from forestry.models import OwnerType
+
+
+class StrictCharField(serializers.CharField):
+    def to_internal_value(self, data):
+        if not isinstance(data, str):
+            self.fail("invalid")
+        return super().to_internal_value(data)
+
+
+class StrictIntegerField(serializers.IntegerField):
+    def to_internal_value(self, data):
+        if isinstance(data, bool) or not isinstance(data, int):
+            self.fail("invalid")
+        return super().to_internal_value(data)
+
+
+class StrictBooleanField(serializers.BooleanField):
+    def to_internal_value(self, data):
+        if not isinstance(data, bool):
+            self.fail("invalid")
+        return data
+
+
+class StrictChoiceField(serializers.ChoiceField):
+    def to_internal_value(self, data):
+        if not isinstance(data, str):
+            self.fail("invalid_choice", input=data)
+        return super().to_internal_value(data)
+
+
+class StrictListField(serializers.ListField):
+    def to_internal_value(self, data):
+        if not isinstance(data, list):
+            self.fail("not_a_list", input_type=type(data).__name__)
+        return super().to_internal_value(data)
+
+
+class LegacyDateTimeField(serializers.Field):
+    """Accept the two explicitly documented legacy date formats: epoch-ms or ISO-8601."""
+
+    default_error_messages = {"invalid": "Expected epoch milliseconds or an ISO-8601 datetime string."}
+
+    def to_internal_value(self, data):
+        if isinstance(data, bool):
+            self.fail("invalid")
+        if isinstance(data, int):
+            try:
+                return datetime.fromtimestamp(data / 1000)
+            except (OverflowError, OSError, ValueError):
+                self.fail("invalid")
+        if isinstance(data, str):
+            parsed = parse_datetime(data.replace("Z", "+00:00"))
+            if parsed is not None:
+                return parsed
+        self.fail("invalid")
+
+    def to_representation(self, value):
+        return value.isoformat()
+
+
+class AdminUserCreateSerializer(serializers.Serializer):
+    id = StrictCharField(max_length=50)
+    name = StrictCharField(max_length=100)
+    password = StrictCharField(min_length=12, write_only=True)
+    privileges = StrictListField(child=StrictChoiceField(choices=PrivilegeCode.values), required=False, default=list)
+
+
+class AdminUserUpdateSerializer(serializers.Serializer):
+    name = StrictCharField(max_length=100, required=False)
+    privileges = StrictListField(child=StrictChoiceField(choices=PrivilegeCode.values), required=False)
+
+    def validate(self, attrs):
+        if not attrs:
+            raise serializers.ValidationError("At least one editable field is required.")
+        return attrs
+
+
+class OwnerStatusWriteSerializer(serializers.Serializer):
+    id = StrictCharField(max_length=100)
+    colorHex = StrictCharField(min_length=6, max_length=7, required=False)
+    durationDays = StrictIntegerField(min_value=0, required=False)
+    protectedStatus = StrictBooleanField(required=False)
+
+    def validate_colorHex(self, value: str) -> str:
+        clean = value.removeprefix("#")
+        if len(clean) != 6 or any(ch not in "0123456789abcdefABCDEF" for ch in clean):
+            raise serializers.ValidationError("Expected a six-digit hexadecimal color.")
+        return value
+
+
+class OwnerCreateSerializer(serializers.Serializer):
+    ownerName = StrictCharField(max_length=100, required=False)
+    name = StrictCharField(max_length=100, required=False)
+    ownerType = StrictChoiceField(choices=OwnerType.values, required=False)
+    type = StrictChoiceField(choices=OwnerType.values, required=False)
+
+    def validate(self, attrs):
+        if not (attrs.get("ownerName") or attrs.get("name")):
+            raise serializers.ValidationError({"name": "Owner name is required."})
+        return attrs
+
+
+class OwnerUpdateSerializer(serializers.Serializer):
+    version = StrictIntegerField(min_value=1)
+    name = StrictCharField(max_length=100, required=False, allow_blank=True)
+    type = StrictChoiceField(choices=OwnerType.values, required=False, allow_blank=True)
+    phone = StrictCharField(max_length=100, required=False, allow_blank=True)
+    email = serializers.EmailField(max_length=100, required=False, allow_blank=True)
+    address = StrictCharField(max_length=500, required=False, allow_blank=True)
+    info = StrictCharField(required=False, allow_blank=True)
+    out_of_admin_search_reason = StrictCharField(max_length=50, required=False, allow_blank=True)
+
+
+class VersionedStatusSerializer(serializers.Serializer):
+    version = StrictIntegerField(min_value=1)
+    code = StrictCharField(max_length=100)
+
+
+class AssigneeSerializer(serializers.Serializer):
+    version = StrictIntegerField(min_value=1)
+    assignee = StrictCharField(max_length=50, required=False, allow_blank=True, allow_null=True)
+
+
+class OwnerLogSerializer(serializers.Serializer):
+    message = StrictCharField(allow_blank=False)
+
+
+class MarkCadastresSerializer(serializers.Serializer):
+    cadastres = StrictListField(child=StrictCharField(max_length=50))
+
+
+class CadastreEvaluationSerializer(serializers.Serializer):
+    ownerPrice = StrictCharField(max_length=255, required=False, allow_blank=True)
+    ourPrice = StrictCharField(max_length=255, required=False, allow_blank=True)
+
+
+class AdminWorkdeskAssignSerializer(serializers.Serializer):
+    owners = StrictListField(child=StrictCharField(max_length=50), allow_empty=False)
+    userId = StrictCharField(max_length=50)
+    reassign = StrictBooleanField(required=False)
+
+
+class ReminderCreateSerializer(serializers.Serializer):
+    ownerId = StrictCharField(max_length=50, required=False, allow_blank=True)
+    dueTime = LegacyDateTimeField()
+    text = StrictCharField(required=False, allow_blank=True)
+    cadastre = StrictCharField(required=False, allow_blank=True)
+    propertyName = StrictCharField(required=False, allow_blank=True)
+
+
+class PersonDumpCreateSerializer(serializers.Serializer):
+    source = StrictCharField(max_length=100, required=False, allow_blank=True)
+    name = StrictCharField(max_length=100)
+    phone = StrictCharField(max_length=100, required=False, allow_blank=True)
+    address = StrictCharField(max_length=500, required=False, allow_blank=True)
+    code = StrictCharField(max_length=20, required=False, allow_blank=True)
+
+
+class SendMessageSerializer(serializers.Serializer):
+    recipient = StrictCharField(max_length=50)
+    message = StrictCharField(allow_blank=False)
+
+
+class MarkMessagesReadSerializer(serializers.Serializer):
+    ids = StrictListField(child=StrictIntegerField(min_value=1), required=False)
+    markReadUntil = LegacyDateTimeField(required=False)
+
+    def validate(self, attrs):
+        if "ids" in attrs and "markReadUntil" in attrs:
+            raise serializers.ValidationError("Use ids or markReadUntil, not both.")
+        return attrs
+
+
+class ContractUploadSerializer(serializers.Serializer):
+    file = serializers.FileField(required=True)
+    version = StrictIntegerField(min_value=1, required=False)
+
+    def validate_file(self, upload):
+        if getattr(upload, "content_type", "") not in {"application/pdf", "application/x-pdf"}:
+            raise serializers.ValidationError("Only PDF contract files are accepted.")
+        return upload
+
+
+MUTATION_RULES: tuple[tuple[str, str, type[serializers.Serializer]], ...] = (
+    ("POST", r"^/services/admin/users$", AdminUserCreateSerializer),
+    ("POST", r"^/services/admin/users/[^/]+$", AdminUserUpdateSerializer),
+    ("POST", r"^/services/owner-statuses$", OwnerStatusWriteSerializer),
+    ("POST", r"^/services/owners/[^/]+/add$", OwnerCreateSerializer),
+    ("POST", r"^/services/owners/[^/]+$", OwnerUpdateSerializer),
+    ("POST", r"^/services/owners/[^/]+/change-status$", VersionedStatusSerializer),
+    ("POST", r"^/services/owner/[^/]+/status$", VersionedStatusSerializer),
+    ("POST", r"^/services/owner/[^/]+/assignee$", AssigneeSerializer),
+    ("POST", r"^/services/owners/[^/]+/log$", OwnerLogSerializer),
+    ("POST", r"^/services/owners/[^/]+/mark-cadastres$", MarkCadastresSerializer),
+    ("POST", r"^/services/cadastres/[^/]+/evaluation$", CadastreEvaluationSerializer),
+    ("POST", r"^/services/admin-workdesk/assign$", AdminWorkdeskAssignSerializer),
+    ("POST", r"^/services/reminders$", ReminderCreateSerializer),
+    ("POST", r"^/services/persons-dump$", PersonDumpCreateSerializer),
+    ("POST", r"^/services/messages/send$", SendMessageSerializer),
+    ("POST", r"^/services/messages/(read|received/mark-as-read)$", MarkMessagesReadSerializer),
+    ("POST", r"^/services/contracts/[^/]+/document$", ContractUploadSerializer),
+)
+
+
+def validation_error_payload(errors: Any, *, status_code: int, correlation_id: str | None) -> dict[str, Any]:
+    return {
+        "detail": "Request validation failed.",
+        "code": "validation_error",
+        "errors": errors,
+        "status": status_code,
+        "correlationId": correlation_id or None,
+    }

--- a/django_backend/api/mutation_serializers.py
+++ b/django_backend/api/mutation_serializers.py
@@ -2,8 +2,8 @@
 
 The legacy API accepts a number of historical field names, but it must not silently
 coerce booleans, numbers or collection values into another type. These serializers
-are intentionally validation-only: existing views keep their response compatibility
-while every registered mutation is type-checked before it reaches persistence code.
+are validation-only: existing views keep response compatibility while registered
+mutations are type-checked before persistence code runs.
 """
 
 from __future__ import annotations
@@ -53,8 +53,15 @@ class StrictListField(serializers.ListField):
         return super().to_internal_value(data)
 
 
+class StrictUUIDField(serializers.UUIDField):
+    def to_internal_value(self, data):
+        if not isinstance(data, str):
+            self.fail("invalid", value=data)
+        return super().to_internal_value(data)
+
+
 class LegacyDateTimeField(serializers.Field):
-    """Accept the two explicitly documented legacy date formats: epoch-ms or ISO-8601."""
+    """Accept only the two documented legacy date formats: epoch-ms or ISO-8601."""
 
     default_error_messages = {"invalid": "Expected epoch milliseconds or an ISO-8601 datetime string."}
 
@@ -79,7 +86,7 @@ class LegacyDateTimeField(serializers.Field):
 class AdminUserCreateSerializer(serializers.Serializer):
     id = StrictCharField(max_length=50)
     name = StrictCharField(max_length=100)
-    password = StrictCharField(min_length=12, write_only=True)
+    password = StrictCharField(write_only=True)
     privileges = StrictListField(child=StrictChoiceField(choices=PrivilegeCode.values), required=False, default=list)
 
 
@@ -119,7 +126,7 @@ class OwnerCreateSerializer(serializers.Serializer):
 
 
 class OwnerUpdateSerializer(serializers.Serializer):
-    version = StrictIntegerField(min_value=1)
+    version = StrictIntegerField(min_value=1, required=False)
     name = StrictCharField(max_length=100, required=False, allow_blank=True)
     type = StrictChoiceField(choices=OwnerType.values, required=False, allow_blank=True)
     phone = StrictCharField(max_length=100, required=False, allow_blank=True)
@@ -130,12 +137,12 @@ class OwnerUpdateSerializer(serializers.Serializer):
 
 
 class VersionedStatusSerializer(serializers.Serializer):
-    version = StrictIntegerField(min_value=1)
+    version = StrictIntegerField(min_value=1, required=False)
     code = StrictCharField(max_length=100)
 
 
 class AssigneeSerializer(serializers.Serializer):
-    version = StrictIntegerField(min_value=1)
+    version = StrictIntegerField(min_value=1, required=False)
     assignee = StrictCharField(max_length=50, required=False, allow_blank=True, allow_null=True)
 
 
@@ -150,12 +157,6 @@ class MarkCadastresSerializer(serializers.Serializer):
 class CadastreEvaluationSerializer(serializers.Serializer):
     ownerPrice = StrictCharField(max_length=255, required=False, allow_blank=True)
     ourPrice = StrictCharField(max_length=255, required=False, allow_blank=True)
-
-
-class AdminWorkdeskAssignSerializer(serializers.Serializer):
-    owners = StrictListField(child=StrictCharField(max_length=50), allow_empty=False)
-    userId = StrictCharField(max_length=50)
-    reassign = StrictBooleanField(required=False)
 
 
 class ReminderCreateSerializer(serializers.Serializer):
@@ -191,12 +192,19 @@ class MarkMessagesReadSerializer(serializers.Serializer):
 
 class ContractUploadSerializer(serializers.Serializer):
     file = serializers.FileField(required=True)
-    version = StrictIntegerField(min_value=1, required=False)
 
     def validate_file(self, upload):
         if getattr(upload, "content_type", "") not in {"application/pdf", "application/x-pdf"}:
             raise serializers.ValidationError("Only PDF contract files are accepted.")
         return upload
+
+
+class ContractGenerateSerializer(serializers.Serializer):
+    dealId = StrictUUIDField()
+    templateId = StrictUUIDField()
+    contractId = StrictCharField(max_length=100, required=False)
+    contractNumber = StrictCharField(max_length=50)
+    version = StrictIntegerField(min_value=1, required=False)
 
 
 MUTATION_RULES: tuple[tuple[str, str, type[serializers.Serializer]], ...] = (
@@ -211,12 +219,12 @@ MUTATION_RULES: tuple[tuple[str, str, type[serializers.Serializer]], ...] = (
     ("POST", r"^/services/owners/[^/]+/log$", OwnerLogSerializer),
     ("POST", r"^/services/owners/[^/]+/mark-cadastres$", MarkCadastresSerializer),
     ("POST", r"^/services/cadastres/[^/]+/evaluation$", CadastreEvaluationSerializer),
-    ("POST", r"^/services/admin-workdesk/assign$", AdminWorkdeskAssignSerializer),
     ("POST", r"^/services/reminders$", ReminderCreateSerializer),
     ("POST", r"^/services/persons-dump$", PersonDumpCreateSerializer),
     ("POST", r"^/services/messages/send$", SendMessageSerializer),
     ("POST", r"^/services/messages/(read|received/mark-as-read)$", MarkMessagesReadSerializer),
     ("POST", r"^/services/contracts/[^/]+/document$", ContractUploadSerializer),
+    ("POST", r"^/services/contracts/generate-from-deal$", ContractGenerateSerializer),
 )
 
 

--- a/django_backend/api/tests_mutation_validation.py
+++ b/django_backend/api/tests_mutation_validation.py
@@ -4,7 +4,13 @@ from django.test import RequestFactory, SimpleTestCase
 from rest_framework.response import Response
 
 from api.middleware import TraceContextMiddleware, _normalize_error_response
-from api.mutation_serializers import OwnerCreateSerializer, OwnerStatusWriteSerializer, ReminderCreateSerializer
+from api.mutation_serializers import (
+    ContractGenerateSerializer,
+    OwnerCreateSerializer,
+    OwnerStatusWriteSerializer,
+    OwnerUpdateSerializer,
+    ReminderCreateSerializer,
+)
 
 
 class StrictMutationSerializerTests(SimpleTestCase):
@@ -27,6 +33,18 @@ class StrictMutationSerializerTests(SimpleTestCase):
         self.assertTrue(valid.is_valid(), valid.errors)
         self.assertFalse(invalid.is_valid())
         self.assertIn("dueTime", invalid.errors)
+
+    def test_uuid_references_are_validated(self):
+        serializer = ContractGenerateSerializer(
+            data={"dealId": "not-a-uuid", "templateId": "also-not-a-uuid", "contractNumber": "L-1"}
+        )
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("dealId", serializer.errors)
+        self.assertIn("templateId", serializer.errors)
+
+    def test_version_can_remain_in_if_match_header(self):
+        serializer = OwnerUpdateSerializer(data={"name": "Uus nimi"})
+        self.assertTrue(serializer.is_valid(), serializer.errors)
 
 
 class MutationValidationMiddlewareTests(SimpleTestCase):

--- a/django_backend/api/tests_mutation_validation.py
+++ b/django_backend/api/tests_mutation_validation.py
@@ -1,0 +1,54 @@
+import json
+
+from django.test import RequestFactory, SimpleTestCase
+from rest_framework.response import Response
+
+from api.middleware import TraceContextMiddleware, _normalize_error_response
+from api.mutation_serializers import OwnerCreateSerializer, OwnerStatusWriteSerializer, ReminderCreateSerializer
+
+
+class StrictMutationSerializerTests(SimpleTestCase):
+    def test_owner_type_rejects_non_string_instead_of_coercing(self):
+        serializer = OwnerCreateSerializer(data={"name": "Test", "type": 123})
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("type", serializer.errors)
+
+    def test_boolean_and_integer_fields_do_not_coerce_strings(self):
+        serializer = OwnerStatusWriteSerializer(
+            data={"id": "CALL_BACK", "durationDays": "7", "protectedStatus": "false"}
+        )
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("durationDays", serializer.errors)
+        self.assertIn("protectedStatus", serializer.errors)
+
+    def test_legacy_datetime_accepts_only_explicit_formats(self):
+        valid = ReminderCreateSerializer(data={"dueTime": 1788512400000, "text": "Call"})
+        invalid = ReminderCreateSerializer(data={"dueTime": {"tomorrow": True}, "text": "Call"})
+        self.assertTrue(valid.is_valid(), valid.errors)
+        self.assertFalse(invalid.is_valid())
+        self.assertIn("dueTime", invalid.errors)
+
+
+class MutationValidationMiddlewareTests(SimpleTestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def test_registered_mutation_returns_consistent_400_envelope(self):
+        request = self.factory.post(
+            "/api/services/owner-statuses",
+            data=json.dumps({"id": "NEW", "durationDays": "10"}),
+            content_type="application/json",
+        )
+        response = TraceContextMiddleware(lambda _: Response({"ok": True}))(request)
+        payload = json.loads(response.content)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(payload["code"], "validation_error")
+        self.assertEqual(payload["status"], 400)
+        self.assertIn("correlationId", payload)
+        self.assertIn("durationDays", payload["errors"])
+
+    def test_conflict_response_is_normalized(self):
+        response = _normalize_error_response(Response({"detail": "Conflict"}, status=409))
+        self.assertEqual(response.data["status"], 409)
+        self.assertEqual(response.data["code"], "conflict")
+        self.assertIn("correlationId", response.data)


### PR DESCRIPTION
## Kokkuvõte

Toob värskele `main` harule üle API-02 veel puuduvad write-side lepingud. Kõik registreeritud mutatsioonid kasutavad rangeid DRF serialiseerijaid, mis lükkavad tagasi tundmatud väljad ja vaikiva tüübiteisenduse. Ühtne middleware normaliseerib 400/403/404/409 vead stabiilseks vormiks ning säilitab If-Match konkurentsipäise toe.

Lisatud on UUID-, enum-, boolean-, kuupäeva-, massiivi- ja failiväljade range valideerimine ning regressioonid legacy epoch-millisekundite ühilduvusele.

## Lokaalne valideerimine

| Kontroll | Tulemus |
|---|---|
| `api.tests_mutation_validation` SpatiaLite’is | Läbis; 7 testi |
| `manage.py check` | Läbis |
| Python-süntaksikontroll | Läbis |

Closes #17.
